### PR TITLE
Update to v6.2.6

### DIFF
--- a/JHUGenerator/mod_Kinematics.F90
+++ b/JHUGenerator/mod_Kinematics.F90
@@ -3428,8 +3428,8 @@ integer,parameter :: swPDF_u=1, swPDF_d=1, swPDF_c=1, swPDF_s=1, swPDF_b=1, swPD
 real(8) :: pdf(-6:6,1:2),NNpdf(1:2,-6:7)
 
 !set top components zero
-        pdf(-5,1:2) = 0d0
-        pdf( 5,1:2) = 0d0
+        pdf( Top_,1:2) = 0d0
+        pdf(ATop_,1:2) = 0d0
 
         PDFScale=MuFac*100d0
         

--- a/JHUGenerator/mod_Parameters.F90
+++ b/JHUGenerator/mod_Parameters.F90
@@ -3,7 +3,7 @@ implicit none
 save
 ! 
 ! 
-character(len=6),parameter :: JHUGen_Version="v6.2.5"
+character(len=6),parameter :: JHUGen_Version="v6.2.6"
 ! 
 ! 
 integer, public :: Collider, PDFSet,PChannel,Process,DecayMode1,DecayMode2,TopDecays

--- a/Manual/manJHUGenerator.tex
+++ b/Manual/manJHUGenerator.tex
@@ -24,7 +24,7 @@ Manual for the JHU generator
 \begin{center}
 \small
 For simulation of a single-produced resonance at hadron colliders \\
-(version v5.6.3, release date June 8, 2015) \\
+(version v5.6.3, release date July 16, 2015) \\
 \normalsize
 \end{center}
 
@@ -698,9 +698,7 @@ In going from \verb|v5.2.5| to \verb|v5.6.3|, the updates are as follows:
 \item Allow $W$ from $ttH$ to decay to any decay mode
 \item Allow $W$ to decay to off-diagonal elements of the CKM matrix
 \item Add support for LHAPDF linking
-\item Upgrade to MCFM 7
 \item Fixes for LHE printout in $VBF$, $Hjj$, and $VH$
-\item JHUGenMELA: add $bbH$ production process
 \end{itemize}
 
 \noindent
@@ -714,7 +712,6 @@ In going from \verb|v4.8.1| to \verb|v5.2.5|, the updates are as follows:
 \item Fixes for smoother reading of LHE files: mother assignment and invariant mass for all intermediate particles
 \item Add \verb|ConvertLHE| option for converting VH decay to any DecayMode
 \item In \verb|ReadLHE| and \verb|ConvertLHE|, preserve comments and optional tags from the input LHE
-\item JHUGenMELA: add $ttH$ production process (both with and without top decay)
 \end{itemize}
 
 \noindent

--- a/Web/Generator/makeTAR.sh
+++ b/Web/Generator/makeTAR.sh
@@ -1,0 +1,6 @@
+#!bin/bash/
+
+INDIR="../../"
+VERSION=$1
+
+tar -czvf "JHUGenerator."$VERSION".tar.gz" $INDIR"/JHUGenerator" $INDIR"/JHUGenMELA" $INDIR"/AnalyticMELA"


### PR DESCRIPTION
1) Replace hardcoded 5, -5 with Top_, ATop_
2) Remove MELA-related stuff from manual (to be updated)
3) Add bash script to make tar.gz files automatically
4) Increment version number to v6.2.6 to be submitted for CMS production
