### PR TITLE
Levi-Civita tensor ANTISYMMETRIC() minus sign removed

### DIFF
--- a/JHUGenerator/mod_VHiggs.F90
+++ b/JHUGenerator/mod_VHiggs.F90
@@ -480,7 +480,7 @@ contains
 
       integer i,j,k,l
 
-      ANTISYMMETRIC=-dble((i-j)*(i-k)*(i-l)*(j-k)*(j-l)*(k-l))/12d0
+      ANTISYMMETRIC=dble((i-j)*(i-k)*(i-l)*(j-k)*(j-l)*(k-l))/12d0
 
       return
       END function ANTISYMMETRIC


### PR DESCRIPTION
Levi-Civita tensor ANTISYMMETRIC() minus sign removed, so that
ANTISYMMETRIC(0,1,2,3)=1
