### PR TITLE
ff > Z scaled in VH

### DIFF
--- a/JHUGenMELA/mod_VHiggs_MatEl.F90
+++ b/JHUGenMELA/mod_VHiggs_MatEl.F90
@@ -217,7 +217,7 @@ end subroutine EvalAmp_VHiggs
         else
           current1=(0.5d0*T3lL - QlL*sitW**2) *Vcurrent1 -(0.5d0*T3lL)*Acurrent1
         endif
-        current1=current1*gFFZ
+        current1=current1*gFFZ*dsqrt(scale_alpha_Z_ll)
 
 !u u~ Z vertex for incoming states
       else if((abs(id(1)).eq.2).or.(abs(id(1)).eq.4))then
@@ -226,7 +226,7 @@ end subroutine EvalAmp_VHiggs
         else
           current1=(0.5d0*T3uL - QuL*sitW**2) *Vcurrent1 -(0.5d0*T3uL)*Acurrent1
         endif
-        current1=current1*gFFZ
+        current1=current1*gFFZ*dsqrt(scale_alpha_Z_uu)
 !d d~ Z vertex for incoming states
       else if((abs(id(1)).eq.1).or.(abs(id(1)).eq.3).or.(abs(id(1)).eq.5))then
         if((id(1)*helicity(1)).gt.0d0)then
@@ -234,7 +234,7 @@ end subroutine EvalAmp_VHiggs
         else
           current1=(0.5d0*T3dL - QdL*sitW**2) *Vcurrent1 -(0.5d0*T3dL)*Acurrent1
         endif
-        current1=current1*gFFZ
+        current1=current1*gFFZ*dsqrt(scale_alpha_Z_dd)
 
       else
       current1=0d0

--- a/JHUGenerator/mod_VHiggs.F90
+++ b/JHUGenerator/mod_VHiggs.F90
@@ -154,7 +154,7 @@ contains
         else
           current1=(0.5d0*T3lL - QlL*sitW**2) *Vcurrent1 -(0.5d0*T3lL)*Acurrent1
         endif
-        current1=current1*gFFZ
+        current1=current1*gFFZ*dsqrt(scale_alpha_Z_ll)
 
 !u u~ Z vertex for incoming states
       else if((abs(id(1)).eq.2).or.(abs(id(1)).eq.4))then
@@ -163,7 +163,7 @@ contains
         else
           current1=(0.5d0*T3uL - QuL*sitW**2) *Vcurrent1 -(0.5d0*T3uL)*Acurrent1
         endif
-        current1=current1*gFFZ
+        current1=current1*gFFZ*dsqrt(scale_alpha_Z_uu)
 !d d~ Z vertex for incoming states
       else if((abs(id(1)).eq.1).or.(abs(id(1)).eq.3).or.(abs(id(1)).eq.5))then
         if((id(1)*helicity(1)).gt.0d0)then
@@ -171,8 +171,7 @@ contains
         else
           current1=(0.5d0*T3dL - QdL*sitW**2) *Vcurrent1 -(0.5d0*T3dL)*Acurrent1
         endif
-        current1=current1*gFFZ
-
+        current1=current1*gFFZ*dsqrt(scale_alpha_Z_dd)
       else
       current1=0d0
       print *, "invalid incoming state"


### PR DESCRIPTION
scale_alpha_Z_uu, dd, etc were implemented for outgoing but not
incoming partons. Now the scaling due to alpha corrections is
consistently implemented for ZH and WH in both incoming and outgoing
ffV vertices.
