### PR TITLE
Fixes

### DIFF
--- a/JHUGenerator/main.F90
+++ b/JHUGenerator/main.F90
@@ -24,7 +24,7 @@ real(8) :: VG_Result,VG_Error
    call WriteParameters(io_stdout)
    call WriteParameters(io_LogFile)
    if ( .not. ReadLHEFile .and. .not. ConvertLHEFile .and. .not.((Process.eq.60 .or. Process.eq.61) .and. unweighted) ) then
-      call InitOutput(-1d0, -1d0)   !for VBF/HJJ the cross section is calculated, so use that in the <init> block
+      call InitOutput(1d0, 1d14)   !for VBF/HJJ the cross section is calculated, so use that in the <init> block
    endif
    write(io_stdout,*) " Running"
    if( ConvertLHEFile ) then
@@ -1524,17 +1524,17 @@ if( VegasNc1.eq.-1 .and. .not.VegasNc2.eq.-1 ) VegasNc1 = VegasNc2
      do while ( .not.FirstEvent )
         read(16,fmt="(A160)",IOSTAT=stat,END=99) FirstLines
         if ( FirstLines(1:4).eq."<!--" .and. .not.WroteHeader ) then
-            call InitOutput(-1d0, -1d0)
+            call InitOutput(1d0, 1d14)
             WroteHeader = .true.
         endif
         if (index(FirstLines,"<MG").ne.0 .and. .not.WroteHeader) then  !Sometimes MadGraph doesn't have a comment at the beginning
-            call InitOutput(-1d0, -1d0)                                !In that case put the JHUGen header before the MadGraph
+            call InitOutput(1d0, 1d14)                                 !In that case put the JHUGen header before the MadGraph
             write(io_LHEOutFile, "(A)") "-->"                          ! proc card, etc.
             WroteHeader = .true.                                       !and put the Higgs mass/width in a separate comment
             ClosedHeader = .true.                                      !before <init>
         endif
         if (Index(FirstLines,"<init>").ne.0 .and. .not.WroteHeader ) then !If not now, when?
-            call InitOutput(-1d0, -1d0)
+            call InitOutput(1d0, 1d14)
             WroteHeader = .true.
         endif
 
@@ -1913,17 +1913,17 @@ if( VegasNc1.eq.-1 .and. .not.VegasNc2.eq.-1 ) VegasNc1 = VegasNc2
      do while ( .not.FirstEvent )
         read(16,fmt="(A160)",IOSTAT=stat,END=99) FirstLines
         if ( FirstLines(1:4).eq."<!--" .and. .not.WroteHeader ) then
-            call InitOutput(-1d0, -1d0)
+            call InitOutput(1d0, 1d14)
             WroteHeader = .true.
         endif
         if (index(FirstLines,"<MG").ne.0 .and. .not.WroteHeader) then  !Sometimes MadGraph doesn't have a comment at the beginning
-            call InitOutput(-1d0, -1d0)                                !In that case put the JHUGen header before the MadGraph
+            call InitOutput(1d0, 1d14)                                 !In that case put the JHUGen header before the MadGraph
             write(io_LHEOutFile, "(A)") "-->"                          ! proc card, etc.
             WroteHeader = .true.                                       !and put the Higgs mass/width in a separate comment
             ClosedHeader = .true.                                      !before <init>
         endif
         if (Index(FirstLines,"<init>").ne.0 .and. .not.WroteHeader ) then !If not now, when?
-            call InitOutput(-1d0, -1d0)
+            call InitOutput(1d0, 1d14)
             WroteHeader = .true.
         endif
 

--- a/JHUGenerator/main.F90
+++ b/JHUGenerator/main.F90
@@ -3291,7 +3291,7 @@ real(8) :: CrossSection, CrossSectionError
 ! (*) pdf code of LHAGLUE for colliding particles (10042=CTEQ6Ll, MSTW2008=21000,21041-21080)    
 ! (*) weighting strategy (3=unweighted events, 4=weighted events,  otherwise=see LHE manuals)
 ! (*) number of process types to be accepted (default=1, otherwise=see manual)
-            write(io_LHEOutFile ,'(1PE14.7,1PE14.7,1PE14.7,I3)') CrossSection, CrossSectionError, 1.00000000000E-00, Process
+            write(io_LHEOutFile ,'(1PE14.7,1X,1PE14.7,1X,1PE14.7,1X,I3)') CrossSection, CrossSectionError, 1.00000000000E-00, Process
 ! in order of appearance: 
 ! (*) total cross section in pb
 ! (*) stat. error in the total cross section in pb

--- a/JHUGenerator/main.F90
+++ b/JHUGenerator/main.F90
@@ -23,8 +23,8 @@ real(8) :: VG_Result,VG_Error
    call PrintLogo(io_LogFile)
    call WriteParameters(io_stdout)
    call WriteParameters(io_LogFile)
-   if ( .not. ReadLHEFile .and. .not. ConvertLHEFile ) then
-      call InitOutput()
+   if ( .not. ReadLHEFile .and. .not. ConvertLHEFile .and. .not.((Process.eq.60 .or. Process.eq.61) .and. unweighted) ) then
+      call InitOutput(-1d0, -1d0)   !for VBF/HJJ the cross section is calculated, so use that in the <init> block
    endif
    write(io_stdout,*) " Running"
    if( ConvertLHEFile ) then
@@ -1187,6 +1187,7 @@ if( UseBetaVersion ) then
     CrossSec(:,:) = CrossSec(:,:)/dble(itmx)    
     write(io_stdout,"(A)")  ""
     write(io_stdout,"(2X,A,F10.3,A,F10.3,A,F10.3)") "Total xsec: ",VG_Result, " +/-",VG_Error, " fb    vs.",sum(CrossSec(:,:))
+    call InitOutput(VG_Result, VG_Error)
 
     RequEvents(:,:)=0
     do i1=-5,5
@@ -1523,17 +1524,17 @@ if( VegasNc1.eq.-1 .and. .not.VegasNc2.eq.-1 ) VegasNc1 = VegasNc2
      do while ( .not.FirstEvent )
         read(16,fmt="(A160)",IOSTAT=stat,END=99) FirstLines
         if ( FirstLines(1:4).eq."<!--" .and. .not.WroteHeader ) then
-            call InitOutput()
+            call InitOutput(-1d0, -1d0)
             WroteHeader = .true.
         endif
         if (index(FirstLines,"<MG").ne.0 .and. .not.WroteHeader) then  !Sometimes MadGraph doesn't have a comment at the beginning
-            call InitOutput()                                          !In that case put the JHUGen header before the MadGraph
+            call InitOutput(-1d0, -1d0)                                !In that case put the JHUGen header before the MadGraph
             write(io_LHEOutFile, "(A)") "-->"                          ! proc card, etc.
             WroteHeader = .true.                                       !and put the Higgs mass/width in a separate comment
             ClosedHeader = .true.                                      !before <init>
         endif
         if (Index(FirstLines,"<init>").ne.0 .and. .not.WroteHeader ) then !If not now, when?
-            call InitOutput()
+            call InitOutput(-1d0, -1d0)
             WroteHeader = .true.
         endif
 
@@ -1912,17 +1913,17 @@ if( VegasNc1.eq.-1 .and. .not.VegasNc2.eq.-1 ) VegasNc1 = VegasNc2
      do while ( .not.FirstEvent )
         read(16,fmt="(A160)",IOSTAT=stat,END=99) FirstLines
         if ( FirstLines(1:4).eq."<!--" .and. .not.WroteHeader ) then
-            call InitOutput()
+            call InitOutput(-1d0, -1d0)
             WroteHeader = .true.
         endif
         if (index(FirstLines,"<MG").ne.0 .and. .not.WroteHeader) then  !Sometimes MadGraph doesn't have a comment at the beginning
-            call InitOutput()                                          !In that case put the JHUGen header before the MadGraph
+            call InitOutput(-1d0, -1d0)                                !In that case put the JHUGen header before the MadGraph
             write(io_LHEOutFile, "(A)") "-->"                          ! proc card, etc.
             WroteHeader = .true.                                       !and put the Higgs mass/width in a separate comment
             ClosedHeader = .true.                                      !before <init>
         endif
         if (Index(FirstLines,"<init>").ne.0 .and. .not.WroteHeader ) then !If not now, when?
-            call InitOutput()
+            call InitOutput(-1d0, -1d0)
             WroteHeader = .true.
         endif
 
@@ -3243,9 +3244,11 @@ END SUBROUTINE
 
 
 
-SUBROUTINE InitOutput
+SUBROUTINE InitOutput(CrossSection, CrossSectionError)
 use ModParameters
 implicit none
+
+real(8) :: CrossSection, CrossSectionError
 
     if( (unweighted) .or. ( (.not.unweighted) .and. (writeWeightedLHE) )  ) then 
         if ( .not. ReadLHEFile .and. .not. ConvertLHEFile ) then
@@ -3288,8 +3291,7 @@ implicit none
 ! (*) pdf code of LHAGLUE for colliding particles (10042=CTEQ6Ll, MSTW2008=21000,21041-21080)    
 ! (*) weighting strategy (3=unweighted events, 4=weighted events,  otherwise=see LHE manuals)
 ! (*) number of process types to be accepted (default=1, otherwise=see manual)
-! 
-            write(io_LHEOutFile ,'(A)') '0.43538820803E-02  0.72559367904E-05  1.00000000000E-00 100'
+            write(io_LHEOutFile ,'(1PE14.7,1PE14.7,1PE14.7,I3)') CrossSection, CrossSectionError, 1.00000000000E-00, Process
 ! in order of appearance: 
 ! (*) total cross section in pb
 ! (*) stat. error in the total cross section in pb

--- a/JHUGenerator/makefile
+++ b/JHUGenerator/makefile
@@ -169,7 +169,8 @@ else
 endif
 	@echo " executable file is "$(Exec) "compiled with "$(Comp)
 	@echo " "
-	$(fcomp) -o $(Exec) $(MainObj) $(AmpObj) $(PSGenObj) $(VegasObj) $(PDFObj) $(CPSObj) $(MCFM_Obj)
+	$(fcomp) -o $(Exec) $(MainObj) $(AmpObj) $(PSGenObj) $(VegasObj) $(PDFObj) $(CPSObj)
+# $(MCFM_Obj)
 
 
 

--- a/JHUGenerator/mod_CrossSection.F90
+++ b/JHUGenerator/mod_CrossSection.F90
@@ -1501,6 +1501,7 @@ ENDIF! GENEVT
 !    IDUP(7)  -->  MomDK(:,1)  -->  ubar-spinor
 !    IDUP(8)  -->  MomDK(:,4)  -->     v-spinor
 !    IDUP(9)  -->  MomDK(:,3)  -->  ubar-spinor
+    ICOLUP(1:2,1:9) = 0
     call VVBranchings(MY_IDUP(4:9),ICOLUP(1:2,6:9))
     MY_IDUP(1:3) = 0
     yz1 = yRnd(10)
@@ -1722,6 +1723,12 @@ ENDIF! GENEVT
 !    print *, ReweightToCPS( Get_MInv( MomExt(1:4,3)+MomExt(1:4,4) ) );pause
 
    if( writeWeightedLHE .and. (.not. warmup) ) then
+      if (PChannel.eq.0) then
+         My_IDUP(1) = Glu_
+         My_IDUP(2) = Glu_
+         ICOLUP(1:2,1) = (/501,502/)
+         ICOLUP(1:2,2) = (/502,501/)
+      endif
       if( (OffShellV1).or.(OffShellV2).or.(IsAPhoton(DecayMode2))   ) then
             call WriteOutEvent((/MomExt(1:4,1),MomExt(1:4,2),MomDK(1:4,1),MomDK(1:4,2),MomDK(1:4,3),MomDK(1:4,4)/),MY_IDUP(1:9),ICOLUP(1:2,1:9),EventWeight=EvalWeighted*VgsWgt)
       else

--- a/JHUGenerator/mod_CrossSection_HJJ.F90
+++ b/JHUGenerator/mod_CrossSection_HJJ.F90
@@ -100,7 +100,7 @@ EvalWeighted_HJJ_fulldecay = 0d0
 
   i=1; j=-1;
   msq_MCFM(:,:) = 0d0
-  call qq_ZZqq(p_MCFM,msq_MCFM,HZZcoupl,HWWcoupl,Lambda*100d0,Lambda_Q*100d0,(/Lambda_z1,Lambda_z2,Lambda_z3,Lambda_z4/)*100d0)!  q(-p1)+q(-p2)->Z(p3,p4)+Z(p5,p6)+q(p7)+q(p8)
+  !call qq_ZZqq(p_MCFM,msq_MCFM,HZZcoupl,HWWcoupl,Lambda*100d0,Lambda_Q*100d0,(/Lambda_z1,Lambda_z2,Lambda_z3,Lambda_z4/)*100d0)!  q(-p1)+q(-p2)->Z(p3,p4)+Z(p5,p6)+q(p7)+q(p8)
   msq_MCFM(:,:) = msq_MCFM(:,:)/(9.495632068338d-2)**3! removing esq^3
   print *, "new ",msq_MCFM(j,i)
 

--- a/JHUGenerator/mod_Kinematics.F90
+++ b/JHUGenerator/mod_Kinematics.F90
@@ -65,7 +65,7 @@ endif
 
 
 
-IDPRUP=100
+IDPRUP=Process
 if( present(EventWeight) ) then
     XWGTUP=EventWeight
 else
@@ -399,7 +399,7 @@ character(len=150) :: IndentedFmt0, IndentedFmt1
     if( present(EventProcessId) .and. importExternal_LHEinit) then
         IDPRUP=EventProcessId
     else
-        IDPRUP=100
+        IDPRUP=Process
     endif
     if( present(EventWeight) ) then
         XWGTUP=EventWeight
@@ -558,7 +558,7 @@ integer, parameter :: inLeft=1, inRight=2, Hig=3, tauP=4, tauM=5, Wp=6, Wm=7,   
     if( present(EventProcessId) .and. importExternal_LHEinit) then
         IDPRUP=EventProcessId
     else
-        IDPRUP=100
+        IDPRUP=Process
     endif
     if( present(EventWeight) ) then
         XWGTUP=EventWeight
@@ -710,7 +710,7 @@ do i=1,4
 enddo
 
 
-IDPRUP=100
+IDPRUP=Process
 SCALUP=Mu_Fact * 100d0
 AQEDUP=alpha_QED
 AQCDUP=0.11d0
@@ -816,7 +816,7 @@ integer,parameter :: inTop=1, inBot=2, outTop=3, outBot=4, V1=5, V2=6, Lep1P=7, 
 ! For description of the LHE format see http://arxiv.org/abs/hep-ph/0109068 and http://arxiv.org/abs/hep-ph/0609017
 ! The LHE numbering scheme can be found here: http://pdg.lbl.gov/mc_particle_id_contents.html and http://lhapdf.hepforge.org/manual#tth_sEcA
 
-IDPRUP=100
+IDPRUP=Process
 SCALUP=Mu_Fact * 100d0
 AQEDUP=alpha_QED
 AQCDUP=0.11d0
@@ -902,7 +902,7 @@ integer, parameter :: inLeft=1,inRight=2,Hbos=3,tbar=4,t=5,  bbar=6,Wm=7,lepM=8,
 
 
 
-IDPRUP=100
+IDPRUP=Process
 SCALUP=Mu_Fact * 100d0
 AQEDUP=alpha_QED
 AQCDUP=0.11d0
@@ -1022,7 +1022,7 @@ do i=1,5
 enddo
 
 
-IDPRUP=100
+IDPRUP=Process
 SCALUP=Mu_Fact * 100d0
 AQEDUP=alpha_QED
 AQCDUP=0.11d0
@@ -1123,7 +1123,7 @@ integer, parameter :: inLeft=1,inRight=2,Hbos=3,t=4, qout=5, b=6,W=7,lep=8,nu=9
 
 
 
-IDPRUP=100
+IDPRUP=Process
 SCALUP=Mu_Fact * 100d0
 AQEDUP=alpha_QED
 AQCDUP=0.11d0
@@ -1242,7 +1242,7 @@ do i=1,5
 enddo
 
 
-IDPRUP=100
+IDPRUP=Process
 SCALUP=Mu_Fact * 100d0
 AQEDUP=alpha_QED
 AQCDUP=0.11d0
@@ -1378,7 +1378,7 @@ character(len=*),parameter :: Fmt1 = "(6X,I3,2X,I3,3X,I2,3X,I2,2X,I3,2X,I3,X,1PE
 MomDummy = MomExt*1d2
 MassDummy = inv_mass*1d2
 
-IDPRUP=100
+IDPRUP=Process
 SCALUP=Mu_Fact * 100d0
 AQEDUP=alpha_QED
 AQCDUP=0.11d0

--- a/JHUGenerator/mod_Parameters.F90
+++ b/JHUGenerator/mod_Parameters.F90
@@ -46,6 +46,8 @@ integer, public :: Br_W_ll_counter=0
 integer, public :: Br_W_ud_counter=0
 integer, public :: Br_counter(1:5,1:5)=0
 integer, public :: LeptInEvent(0:8) = 0
+logical, public, parameter :: ReweightDecay = .false.
+logical, public, parameter :: PrintRejectedEventsWeightZero = .false.
 !=====================================================
 
 


### PR DESCRIPTION
Turn off decay reweighting by default (flags are in the internal section)
Write cross section as 1+/-10^14 by default

Does not cause a merge conflict with Ulascan (some of the same commits are here but git knows to only do it once)
