### PR TITLE
Decay constants and flat vs non-flat id generations

### DIFF
--- a/JHUGenerator/mod_Graviton.F90
+++ b/JHUGenerator/mod_Graviton.F90
@@ -25,7 +25,7 @@
       integer :: i1,i2,i3,i4,ordering(1:4)
       real(dp) :: aL1,aR1,aL2,aR2
       real(dp) :: gZ_sq
-      real(dp) :: prefactor, Lambda_inv
+      real(dp) :: prefactor
       real(dp), parameter :: symmFact=1d0/2d0
       real(dp) :: intcolfac
 
@@ -38,11 +38,9 @@
       
       gZ_sq = 4.0_dp*pi*alpha_QED/4.0_dp/(one-sitW**2)/sitW**2
 
-!---- the 1/Lambda coupling
-      Lambda_inv = 1.0d0/Lambda
 
 !---- full prefactor; 8 is  the color factor
-      prefactor = 8d0*(Lambda_inv**2)**2*gZ_sq**2
+      prefactor = 8d0*gZ_sq**2
 
 
          if( IsAZDecay(DecayMode1) ) then!  Z decay
@@ -65,7 +63,7 @@
                     aL1=0d0
                     aR1=0d0
               endif
-              prefactor = prefactor *(one/two*M_V*Ga_V)**2
+              prefactor = prefactor
          elseif( IsAWDecay(DecayMode1) ) then !  W decay
               if( IsAQuark(MY_IDUP(6)) ) then
                  aL1 = bL * dsqrt(scale_alpha_W_ud)
@@ -80,7 +78,7 @@
                  aL1=0d0
                  aR1=0d0
               endif
-              prefactor = prefactor *(one/two*M_V*Ga_V)**2
+              prefactor = prefactor
          elseif( IsAPhoton(DecayMode1) ) then !  photon "decay"
               aL1=1d0
               aR1=1d0
@@ -258,7 +256,7 @@ enddo
       integer :: i1,i2,i3,i4,ordering(1:4)
       real(dp) :: aL1,aR1,aL2,aR2,qL,qR
       real(dp) :: gZ_sq
-      real(dp) :: prefactor, Lambda_inv
+      real(dp) :: prefactor
       real(dp), parameter :: symmFact=1d0/2d0
       real(dp) :: intcolfac
 
@@ -278,11 +276,8 @@ enddo
       qL = graviton_qq_left
       qR = graviton_qq_right
 
-!---- the 1/Lambda coupling
-      Lambda_inv = 1.0_dp/Lambda
-
 !---- full prefactor; 3 is  the color factor
-      prefactor = 3d0*(Lambda_inv**2)**2*gZ_sq**2
+      prefactor = 3d0*gZ_sq**2
 
 
          if( IsAZDecay(DecayMode1) ) then!  Z decay
@@ -1436,7 +1431,7 @@ enddo
       integer :: i1,i2,i3,i4
       real(dp) :: aL,aR
       real(dp) :: gZ_sq
-      real(dp) :: prefactor, Lambda_inv
+      real(dp) :: prefactor
 
 
 !---- electroweak couplings
@@ -1446,14 +1441,10 @@ enddo
 
       gZ_sq = 4.0_dp*pi*alpha_QED/4.0_dp/(one-sitW**2)/sitW**2
 
-!---- the 1/Lambda coupling
-
-
-      Lambda_inv = 1.0_dp/Lambda
 
 !---- full prefactor; 3 is  the color factor
 
-      prefactor = 3d0*(Lambda_inv**2)**2*(one/two*M_V*Ga_V)**2*gZ_sq**2
+      prefactor = 3d0*gZ_sq**2
 
       sum = zero
 
@@ -1531,7 +1522,7 @@ enddo
       integer :: i1,i2,i3,i4
       real(dp) :: aL,aR
       real(dp) :: gZ_sq
-      real(dp) :: prefactor, Lambda_inv
+      real(dp) :: prefactor
 
 !---- electroweak couplings
       aL = -one + two*sitW**2
@@ -1540,11 +1531,8 @@ enddo
 
       gZ_sq = 4.0_dp*pi*alpha_QED/4.0_dp/(one-sitW**2)/sitW**2
 
-!---- the 1/Lambda coupling
-      Lambda_inv = 1.0d0/Lambda
-
 !---- full prefactor; 8 is  the color factor
-      prefactor = 8d0*(Lambda_inv**2)**2*(one/two*M_V*Ga_V)**2*gZ_sq**2
+      prefactor = 8d0*gZ_sq**2
 
 
       sum = zero

--- a/JHUGenerator/mod_Higgs.F90
+++ b/JHUGenerator/mod_Higgs.F90
@@ -29,7 +29,7 @@
       complex(dp) :: A_VV(1:8)
       integer :: i1,i2,i3,i4,VVMode
       real(dp) :: gZ_sq
-      real(dp) :: prefactor, Lambda_inv,res2
+      real(dp) :: prefactor,res2
       real(dp), parameter :: symmFact=1d0/2d0
       real(dp) :: intcolfac
 
@@ -52,17 +52,16 @@
          endif
 
 
-! this block can be removed... only global normalization
+! Global normalization
          gZ_sq = 4.0_dp*pi*alpha_QED/4.0_dp/(one-sitW**2)/sitW**2
-         Lambda_inv = 1.0d0/Lambda
          if( VVMode.eq.ZZMode ) then!  Z decay
-              prefactor = 8d0!*(Lambda_inv**2)**2 * (one/two*M_V*Ga_V)**2 *gZ_sq**2          ! removed this for the moment to have O(1) cross sections!
+              prefactor = 8d0*gZ_sq**2
          elseif( VVMode.eq.WWMode ) then !  W decay
-              prefactor = 8d0*(Lambda_inv**2)**2 * (one/two*M_V*Ga_V)**2 *gZ_sq**2 ! the last factor doesnt belong here
+              prefactor = 8d0*gZ_sq**2
          elseif( VVMode.eq.ZgMode ) then !  Z+photon "decay"
-              prefactor = 8d0*(Lambda_inv**2)**2 * (one/two*M_V*Ga_V) *gZ_sq ! Only single powers
+              prefactor = 8d0*gZ_sq ! Only single powers
          elseif( VVMode.eq.ggMode ) then !  photon "decay"
-              prefactor = 8d0*(Lambda_inv**2)**2
+              prefactor = 8d0
          else
               prefactor = 0d0
          endif
@@ -133,7 +132,7 @@
 ! pause
 ! res=res2; RETURN
 
-! res= res*prefactor/(Lambda_inv**2)**2
+! res= res*prefactor
 ! print *, "checker 1",res
 ! print *, "checker 2",res2
 ! print *, "checker 1/2",res/res2
@@ -747,7 +746,7 @@
       complex(dp) :: A_VV(1:8),VVHg1,VVHg2,VVHg3
       integer :: i3,i4,VVMode
       real(dp) :: gZ_sq,s
-      real(dp) :: prefactor, Lambda_inv
+      real(dp) :: prefactor!,res2
       real(dp), parameter :: symmFact=1d0/2d0
       real(dp) :: intcolfac
 
@@ -771,20 +770,20 @@
          endif
 
 
-! this block can be removed... only global normalization
+! Global normalization
          gZ_sq = 4.0_dp*pi*alpha_QED/4.0_dp/(one-sitW**2)/sitW**2
-         Lambda_inv = 1.0d0/Lambda
          if( VVMode.eq.ZZMode ) then!  Z decay
-              prefactor = 8d0*(Lambda_inv**2)**2 * (one/two*M_V*Ga_V)**2 *gZ_sq**2
+              prefactor = 8d0*gZ_sq**2
          elseif( VVMode.eq.WWMode ) then !  W decay
-              prefactor = 8d0*(Lambda_inv**2)**2 * (one/two*M_V*Ga_V)**2 *gZ_sq**2 ! the last factor doesnt belong here
+              prefactor = 8d0*gZ_sq**2
          elseif( VVMode.eq.ZgMode ) then !  Z+photon "decay"
-              prefactor = 8d0*(Lambda_inv**2)**2 * (one/two*M_V*Ga_V) *gZ_sq ! Only single powers
+              prefactor = 8d0*gZ_sq ! Only single powers
          elseif( VVMode.eq.ggMode ) then !  photon "decay"
-              prefactor = 8d0*(Lambda_inv**2)**2
+              prefactor = 8d0
          else
               prefactor = 0d0
          endif
+         prefactor = prefactor * (alphas/(3_dp*pi*vev))**2
 
 
 ! ! MADGRAPH CHECK
@@ -852,7 +851,7 @@
 ! pause
 ! res=res2; RETURN
 
-! res= res*prefactor/(Lambda_inv**2)**2
+! res= res*prefactor
 ! print *, "checker 1",res
 ! print *, "checker 2",res2
 ! print *, "checker 1/2",res/res2

--- a/JHUGenerator/mod_Kinematics.F90
+++ b/JHUGenerator/mod_Kinematics.F90
@@ -2818,6 +2818,7 @@ integer, parameter :: inLeft=1, inRight=2, Hig=3, tauP=4, tauM=5, Wp=6, Wm=7,   
     
 RETURN
 END SUBROUTINE
+
 FUNCTION ZLepBranching(xRnd)
 use ModParameters
 implicit none
@@ -2840,6 +2841,21 @@ integer :: ZLepBranching
 RETURN
 END FUNCTION
 
+FUNCTION ZLepBranching_flat(xRnd)
+use ModParameters
+implicit none
+real(8) :: xRnd
+integer :: ZLepBranching_flat
+
+
+  if( xRnd .le. 0.5d0 ) then
+      ZLepBranching_flat = ElM_
+  else
+      ZLepBranching_flat = MuM_
+  endif
+
+RETURN
+END FUNCTION
 
 
 
@@ -2863,6 +2879,23 @@ integer :: ZLepPlusTauBranching
 ! print *, "checker 3",Brlept_Z_ee
 ! print *, "checker 3",Brlept_Z_ee+Brlept_Z_mm
 ! print *, "checker 3",Brlept_Z_ee+Brlept_Z_mm+Brlept_Z_tt
+
+RETURN
+END FUNCTION
+
+FUNCTION ZLepPlusTauBranching_flat(xRnd)
+use ModParameters
+implicit none
+real(8) :: xRnd
+integer :: ZLepPlusTauBranching_flat
+
+  if( xRnd .le. (1d0/3d0) ) then
+      ZLepPlusTauBranching_flat = ElM_
+  elseif(xRnd .le. (2d0/3d0) ) then
+      ZLepPlusTauBranching_flat = MuM_
+  else
+      ZLepPlusTauBranching_flat = TaM_
+  endif
 
 RETURN
 END FUNCTION
@@ -2893,6 +2926,22 @@ integer :: ZNuBranching
 RETURN
 END FUNCTION
 
+FUNCTION ZNuBranching_flat(xRnd)
+use ModParameters
+implicit none
+real(8) :: xRnd
+integer :: ZNuBranching_flat
+
+  if( xRnd .le. (1d0/3d0) ) then
+      ZNuBranching_flat = NuE_
+  elseif(xRnd .le. (2d0/3d0) ) then
+      ZNuBranching_flat = NuM_
+  else
+      ZNuBranching_flat = NuT_
+  endif
+
+RETURN
+END FUNCTION
 
 
 
@@ -3140,6 +3189,20 @@ integer :: WLepBranching
 RETURN
 END FUNCTION
 
+FUNCTION WLepBranching_flat(xRnd)
+use ModParameters
+implicit none
+real(8) :: xRnd
+integer :: WLepBranching_flat
+
+  if( xRnd .le. 0.5d0 ) then
+      WLepBranching_flat = ElM_
+  else
+      WLepBranching_flat = MuM_
+  endif
+
+RETURN
+END FUNCTION
 
 
 FUNCTION WLepPlusTauBranching(xRnd)
@@ -3166,6 +3229,22 @@ integer :: WLepPlusTauBranching
 RETURN
 END FUNCTION
 
+FUNCTION WLepPlusTauBranching_flat(xRnd)
+use ModParameters
+implicit none
+real(8) :: xRnd
+integer :: WLepPlusTauBranching_flat
+
+  if( xRnd .le. (1d0/3d0) ) then
+      WLepPlusTauBranching_flat = ElM_
+  elseif(xRnd .le. (2d0/3d0) ) then
+      WLepPlusTauBranching_flat = MuM_
+  else
+      WLepPlusTauBranching_flat = TaM_
+  endif
+
+RETURN
+END FUNCTION
 
 
 
@@ -3191,7 +3270,20 @@ integer :: WQuaUpBranching
 RETURN
 END FUNCTION
 
+FUNCTION WQuaUpBranching_flat(xRnd)
+use ModParameters
+implicit none
+real(8) :: xRnd
+integer :: WQuaUpBranching_flat
 
+  if( xRnd .le. 0.5d0 ) then
+      WQuaUpBranching_flat = Up_
+  else
+      WQuaUpBranching_flat = Chm_
+  endif
+
+RETURN
+END FUNCTION
 
 
 FUNCTION WAnyBranching_flat(xRnd)
@@ -3218,7 +3310,6 @@ real(8),parameter :: yy=Ncol*xx
       print *, "error ",xRnd
       stop
   endif
-
 
 RETURN
 END FUNCTION
@@ -3300,7 +3391,7 @@ real(8) :: DKRnd
    if( DecayMode1.eq.0 ) then! Z1->2l
         call random_number(DKRnd)
         MY_IDUP(4) = Z0_
-        DKFlavor = ZLepBranching( DKRnd )!= ElM or MuM
+        DKFlavor = ZLepBranching_flat( DKRnd )!= ElM or MuM
         MY_IDUP(6) =-DKFlavor
         MY_IDUP(7) =+DKFlavor
    elseif( DecayMode1.eq.1 ) then! Z1->2q
@@ -3318,19 +3409,19 @@ real(8) :: DKRnd
    elseif( DecayMode1.eq.3 ) then! Z1->2nu
         call random_number(DKRnd)
         MY_IDUP(4) = Z0_
-        DKFlavor = ZNuBranching( DKRnd )!= NuE,NuM,NuT
+        DKFlavor = ZNuBranching_flat( DKRnd )!= NuE,NuM,NuT
         MY_IDUP(6) =-DKFlavor
         MY_IDUP(7) =+DKFlavor
    elseif( DecayMode1.eq.4 ) then! W1(+)->lnu
         call random_number(DKRnd)
         MY_IDUP(4) = Wp_
-        DKFlavor = WLepBranching( DKRnd )!= ElM or MuM
+        DKFlavor = WLepBranching_flat( DKRnd )!= ElM or MuM
         MY_IDUP(6) = +abs(DKFlavor)     ! lepton(+)
         MY_IDUP(7) = +abs(DKFlavor)+7   ! neutrino        
    elseif( DecayMode1.eq.5 ) then! W1(+)->2q
         call random_number(DKRnd)
         MY_IDUP(4) = Wp_
-        DKFlavor = WQuaUpBranching( DKRnd )!= Up,Chm
+        DKFlavor = WQuaUpBranching_flat( DKRnd )!= Up,Chm
 !         MY_IDUP(6) = -abs(DKFlavor)-1  ! anti-dn flavor
 !         MY_IDUP(7) = +abs(DKFlavor)    ! up flavor
         MY_IDUP(7) = +abs(DKFlavor)           ! up flavor
@@ -3348,7 +3439,7 @@ real(8) :: DKRnd
    elseif( DecayMode1.eq.8 ) then! Z1->2l+2tau
         call random_number(DKRnd)
         MY_IDUP(4) = Z0_
-        DKFlavor = ZLepPlusTauBranching( DKRnd )!= ElM or MuM or TaM
+        DKFlavor = ZLepPlusTauBranching_flat( DKRnd )!= ElM or MuM or TaM
         MY_IDUP(6) =-DKFlavor
         MY_IDUP(7) =+DKFlavor
    elseif( DecayMode1.eq.9 ) then! Z1-> anything
@@ -3364,7 +3455,7 @@ real(8) :: DKRnd
    elseif( DecayMode1.eq.10 ) then! W1(+)->l+tau  +nu
         call random_number(DKRnd)
         MY_IDUP(4) = Wp_
-        DKFlavor = WLepPlusTauBranching( DKRnd )!= ElM or MuM or TaM
+        DKFlavor = WLepPlusTauBranching_flat( DKRnd )!= ElM or MuM or TaM
         MY_IDUP(6) = +abs(DKFlavor)     ! lepton(+)
         MY_IDUP(7) = +abs(DKFlavor)+7   ! neutrino
    elseif( DecayMode1.eq.11 ) then! W1(+)-> anything
@@ -3388,7 +3479,7 @@ real(8) :: DKRnd
    if( DecayMode2.eq.0 ) then! Z2->2l (sample over el,mu)
         call random_number(DKRnd)
         MY_IDUP(5) = Z0_
-        DKFlavor = ZLepBranching( DKRnd )!= ElM or MuM
+        DKFlavor = ZLepBranching_flat( DKRnd )!= ElM or MuM
         MY_IDUP(8) =-DKFlavor
         MY_IDUP(9) =+DKFlavor
    elseif( DecayMode2.eq.1 ) then! Z2->2q
@@ -3406,19 +3497,19 @@ real(8) :: DKRnd
    elseif( DecayMode2.eq.3 ) then! Z2->2nu
         call random_number(DKRnd)
         MY_IDUP(5) = Z0_
-        DKFlavor = ZNuBranching( DKRnd )!= NuE,NuM,NuT
+        DKFlavor = ZNuBranching_flat( DKRnd )!= NuE,NuM,NuT
         MY_IDUP(8) =-DKFlavor
         MY_IDUP(9) =+DKFlavor
    elseif( DecayMode2.eq.4 ) then! W2(-)->lnu
         call random_number(DKRnd)
         MY_IDUP(5) = Wm_
-        DKFlavor = WLepBranching( DKRnd )!= ElM or MuM
+        DKFlavor = WLepBranching_flat( DKRnd )!= ElM or MuM
         MY_IDUP(8) = -abs(DKFlavor)-7   ! anti-neutrino
         MY_IDUP(9) = -abs(DKFlavor)     ! lepton(-)
    elseif( DecayMode2.eq.5 ) then! W2(-)->2q (sample over u,d,s,c)
         call random_number(DKRnd)
         MY_IDUP(5) = Wm_
-        DKFlavor = WQuaUpBranching( DKRnd )!= Up,Chm
+        DKFlavor = WQuaUpBranching_flat( DKRnd )!= Up,Chm
 !         MY_IDUP(8) = -abs(DKFlavor)    ! anti-up flavor
 !         MY_IDUP(9) = +abs(DKFlavor)+1  ! dn flavor
         MY_IDUP(8) = -abs(DKFlavor)           ! up flavor
@@ -3436,7 +3527,7 @@ real(8) :: DKRnd
    elseif( DecayMode2.eq.8 ) then! Z2->2l+2tau
         call random_number(DKRnd)
         MY_IDUP(5) = Z0_
-        DKFlavor = ZLepPlusTauBranching( DKRnd )!= ElM or MuM or TaM
+        DKFlavor = ZLepPlusTauBranching_flat( DKRnd )!= ElM or MuM or TaM
         MY_IDUP(8) =-DKFlavor
         MY_IDUP(9) =+DKFlavor
    elseif( DecayMode2.eq.9 ) then! Z2-> anything
@@ -3452,7 +3543,7 @@ real(8) :: DKRnd
    elseif( DecayMode2.eq.10 ) then! W2(-)->l+tau + nu
         call random_number(DKRnd)
         MY_IDUP(5) = Wm_
-        DKFlavor = WLepPlusTauBranching( DKRnd )!= ElM or MuM or TaM
+        DKFlavor = WLepPlusTauBranching_flat( DKRnd )!= ElM or MuM or TaM
         MY_IDUP(8) = -abs(DKFlavor)-7   ! anti-neutrino
         MY_IDUP(9) = -abs(DKFlavor)     ! lepton(-)
    elseif( DecayMode2.eq.11 ) then! W2(-)-> anything

--- a/JHUGenerator/mod_Zprime.F90
+++ b/JHUGenerator/mod_Zprime.F90
@@ -23,7 +23,7 @@
       integer :: i1,i2,i3,i4,ordering(1:4)
       real(dp) :: aL1,aR1,aL2,aR2
       real(dp) :: gZ_sq
-      real(dp) :: prefactor, Lambda_inv
+      real(dp) :: prefactor
       real(dp), parameter :: symmFact=1d0/2d0
       real(dp) :: intcolfac
 
@@ -39,10 +39,8 @@
       qL = zprime_qq_left
       qR = zprime_qq_right
 
-!---- the 1/Lambda coupling
-      Lambda_inv = 1.0_dp/Lambda
 !---- full prefactor; 3 is  the color factor
-      prefactor = 3d0*(Lambda_inv**2)**2*(one/two*M_V*Ga_V)**2*gZ_sq**2
+      prefactor = 3d0*gZ_sq**2
 
          if( IsAZDecay(DecayMode1) ) then!  Z decay
               if( abs(MY_IDUP(6)).eq.abs(ElM_) .or. abs(MY_IDUP(6)).eq.abs(MuM_) ) then


### PR DESCRIPTION
Changes:
- Lambda_inv is removed from the constants consistently in spin-0, -1, and -2
- Fix to gg/qqbar fraction in spin-2 (gg included the division by on-shell Z propagator while qqb did not)
- Remove extra computations of the random W->ffb and Z->ffb id/color generation due to the involvement of Br\* variables by writing the "flat" versions of the relevant functions as well
