### PR TITLE
better implementation of the P_decay(mzz) calculation

### DIFF
--- a/JHUGenerator/mod_PMZZ.F90
+++ b/JHUGenerator/mod_PMZZ.F90
@@ -68,8 +68,8 @@ SUBROUTINE InitMZZdistribution()
 use ModMisc
 use ModParameters
 implicit none
-integer :: minindex, maxindex, n, mResoindex
-real(8) :: minm4l, maxm4l
+integer :: minindex, maxindex, mResoindex
+real(8) :: minm4l, maxm4l, total, progress
 
     if( ReadPMZZ ) then
         call ReadMZZdistribution(PMZZfile)
@@ -85,13 +85,22 @@ real(8) :: minm4l, maxm4l
         PMZZmaxindex = mResoindex
     endif
 
+    !this is approximate, but just for printing
+    total = 2*Ga_Reso/(1*GeV) + (maxinputmHstar - mininputmHstar + 30*GeV - 2*Ga_Reso)/(5*GeV)
     !extend out to Gamma in steps of 1 GeV
     call ExtendMZZdistribution(M_Reso+Ga_Reso,   1*GeV)
+    progress = Ga_Reso/(1*Gev)
+    print *, progress/total*100, "%"
     call ExtendMZZdistribution(M_Reso-Ga_Reso,   1*GeV)
+    progress = 2*progress
+    print *, progress/total*100, "%"
     !then out to the edge of the distribution in intervals of 5 GeV
     !  with 3 extra points to avoid boundary effects
     call ExtendMZZdistribution(maxinputmHstar+15*GeV, 5*GeV)
+    progress = progress+(maxinputmHstar+15*GeV-M_Reso-Ga_Reso)/(5*GeV)
+    print *, progress/total*100, "%"
     call ExtendMZZdistribution(mininputmHstar-15*GeV, 5*GeV)
+    print *, 100d0, "%"
     !make sure there are a few data points even for a tiny width
     !so that we don't get NaN
     call ExtendMZZdistribution(M_Reso+2*GeV,     1*GeV)

--- a/JHUGenerator/mod_PMZZ.F90
+++ b/JHUGenerator/mod_PMZZ.F90
@@ -88,9 +88,10 @@ real(8) :: minm4l, maxm4l
     !extend out to Gamma in steps of 1 GeV
     call ExtendMZZdistribution(M_Reso+Ga_Reso,   1*GeV)
     call ExtendMZZdistribution(M_Reso-Ga_Reso,   1*GeV)
-    !then out to 5Gamma in steps of 5 GeV
-    call ExtendMZZdistribution(M_Reso+5*Ga_Reso, 5*GeV)
-    call ExtendMZZdistribution(M_Reso-5*Ga_Reso, 5*GeV)
+    !then out to the edge of the distribution in intervals of 5 GeV
+    !  with 3 extra points to avoid boundary effects
+    call ExtendMZZdistribution(maxinputmHstar+15*GeV, 5*GeV)
+    call ExtendMZZdistribution(mininputmHstar-15*GeV, 5*GeV)
     !make sure there are a few data points even for a tiny width
     !so that we don't get NaN
     call ExtendMZZdistribution(M_Reso+2*GeV,     1*GeV)
@@ -113,7 +114,8 @@ real(8) :: extendto, intervalsize, minm4l, maxm4l, ScanMin, ScanMax
     if( PMZZminindex.eq.-1 .or. PMZZmaxindex.eq.-1 ) call Error("Calling ExtendMZZdistribution without calling InitMZZdistribution first!")
     minm4l = PMZZdistribution(PMZZminindex,1)
     maxm4l = PMZZdistribution(PMZZmaxindex,1)
-    extendto = max(extendto, 1d-5)
+    extendto = max(extendto, mininputmHstar-3*intervalsize)
+    extendto = min(extendto, maxinputmHstar+3*intervalsize)
     if( extendto.gt.maxm4l ) then
         ScanMax = extendto
         npoints = ceiling((extendto - maxm4l)/intervalsize)
@@ -159,9 +161,11 @@ logical :: usespline
 
          if( usespline ) then
              if( intervalsize.gt.0d0 ) then
+                 !shouldn't need this anymore, with maxinputmHstar and mininputmHstar above
                  call ExtendMZZdistribution(EHat+3*intervalsize, intervalsize)
                  call ExtendMZZdistribution(EHat-3*intervalsize, intervalsize)
              else
+                 !shouldn't need this anymore, with maxinputmHstar and mininputmHstar above
                  call ExtendMZZdistribution(EHat+15*GeV,         5*GeV)
                  call ExtendMZZdistribution(EHat-15*GeV,         5*GeV)
              endif

--- a/JHUGenerator/mod_Parameters.F90
+++ b/JHUGenerator/mod_Parameters.F90
@@ -74,7 +74,7 @@ integer, public  :: WidthScheme = 0   ! 1=running BW-width, 2=fixed BW-width (de
 integer, public  :: WidthSchemeIn = 0   ! 1=running BW-width, 2=fixed BW-width (default), 3=Passarino's CPS
 real(8), public :: mubarH = -999d0   !for CPS
 real(8), public :: gabarH = -999d0   !for CPS
-real(8), public :: maxInputmHstar = -999d0
+real(8), public :: maxInputmHstar = -999d0, minInputmHstar = 1d15, mHstarforphasespace
 logical, public :: ReadPMZZ
 character(len=500), public :: PMZZfile = "PMZZdistribution.out"
 real(8), public :: PMZZ_mReso = -1d0


### PR DESCRIPTION
I put together the older version before the maxinputmHstar.  This way makes much more sense.

Nothing really changing, just calculate all the useful numbers at the beginning, and don't calculate the useless ones.  For m=Gamma=3 TeV, previously it was calculating values up to 18 TeV, which is pointless.
