### PR TITLE
fix CKM and tautau with no decay

### DIFF
--- a/JHUGenMELAv2/MELA/fortran/mod_Higgs.F90
+++ b/JHUGenMELAv2/MELA/fortran/mod_Higgs.F90
@@ -622,14 +622,14 @@
    SUBROUTINE EvalAmp_H_FF(pin,mass_F,res)
    implicit none
    real(dp), intent(out) ::  res
-   complex(dp) :: amp
+   complex(dp) :: amp2
    real(dp), intent(in) :: pin(1:4,1:2),mass_F
    real(dp)             :: s12
 
       s12=2d0*(pin(1,1)*pin(1,2)-pin(2,1)*pin(2,2)-pin(3,1)*pin(3,2)-pin(4,1)*pin(4,2)) + 2d0*mass_F**2
-      amp =   2d0*s12*(kappa_tilde**2 + kappa**2) - 8d0*mass_F**2*kappa**2
-      amp = amp*mass_F**2/vev**2
-      res = cdabs(amp)
+      amp2 =   2d0*s12*(kappa_tilde**2 + kappa**2) - 8d0*mass_F**2*kappa**2
+      amp2 = amp2*mass_F**2/vev**2
+      res = cdabs(amp2)
 
    RETURN
    END SUBROUTINE

--- a/JHUGenMELAv2/MELA/fortran/mod_Higgs.F90
+++ b/JHUGenMELAv2/MELA/fortran/mod_Higgs.F90
@@ -622,12 +622,14 @@
    SUBROUTINE EvalAmp_H_FF(pin,mass_F,res)
    implicit none
    real(dp), intent(out) ::  res
+   complex(dp) :: amp
    real(dp), intent(in) :: pin(1:4,1:2),mass_F
    real(dp)             :: s12
 
       s12=2d0*(pin(1,1)*pin(1,2)-pin(2,1)*pin(2,2)-pin(3,1)*pin(3,2)-pin(4,1)*pin(4,2)) + 2d0*mass_F**2
-      res =   2d0*s12*(kappa_tilde**2 + kappa**2) - 8d0*mass_F**2*kappa**2
-      res=res*mass_F**2/vev**2
+      amp =   2d0*s12*(kappa_tilde**2 + kappa**2) - 8d0*mass_F**2*kappa**2
+      amp = amp*mass_F**2/vev**2
+      res = cdabs(amp)
 
    RETURN
    END SUBROUTINE

--- a/JHUGenMELAv2/MELA/fortran/mod_HiggsJJ.F90
+++ b/JHUGenMELAv2/MELA/fortran/mod_HiggsJJ.F90
@@ -2333,7 +2333,7 @@ module modHiggsJJ
           kfactor_w = 1.0_dp ! dsqrt(ScaleFactor(iSel,sSel)*ScaleFactor(jSel,rSel))
 
           !if(ZZ_fusion) then ! Special treatment for WW+ZZ interference, not included through phasespace
-          ckm_wfactor = CKM(iSel,sSel)*CKM(jSel,rSel)/dsqrt(ScaleFactor(iSel,sSel)*ScaleFactor(jSel,rSel))
+          ckm_wfactor = CKMbare(iSel,sSel)*CKMbare(jSel,rSel)
           !print *, "iSel, sSel: ",iSel," ",sSel, "; jSel, rSel: ",jSel," ",rSel, ", ckm: ",ckm_wfactor
           !endif
           !print *, "EvalAmp_WBFH_UnSymm_SA_Select_exact: isWW and is-jr"
@@ -2342,7 +2342,7 @@ module modHiggsJJ
           kw2 = 4
           kfactor_w = 1.0_dp ! dsqrt(ScaleFactor(iSel,rSel)*ScaleFactor(jSel,sSel))
 
-          ckm_wfactor = CKM(iSel,rSel)*CKM(jSel,sSel)/dsqrt(ScaleFactor(iSel,rSel)*ScaleFactor(jSel,sSel))
+          ckm_wfactor = CKMbare(iSel,rSel)*CKMbare(jSel,sSel)
           !print *, "iSel, rSel: ",iSel," ",rSel, "; jSel, sSel: ",jSel," ",sSel, ", ckm: ",ckm_wfactor
           !print *, "EvalAmp_WBFH_UnSymm_SA_Select_exact: isWW and ir-js"
        endif

--- a/JHUGenMELAv2/MELA/fortran/mod_Parameters.F90
+++ b/JHUGenMELAv2/MELA/fortran/mod_Parameters.F90
@@ -849,7 +849,7 @@ FUNCTION CKM(id1in,id2in)
 implicit none
 real(8) :: CKM
 integer :: id1in, id2in
-  CKM=CKMbare(id1in, id2in)*ScaleFactor(id1in,id2in)
+  CKM=CKMbare(id1in, id2in)*sqrt(ScaleFactor(id1in,id2in))
 END FUNCTION
 
 

--- a/JHUGenMELAv2/MELA/fortran/mod_VHiggs.F90
+++ b/JHUGenMELAv2/MELA/fortran/mod_VHiggs.F90
@@ -146,7 +146,7 @@ end subroutine EvalAmp_VHiggs
          !WH
          if((id(1)+id(2)).ne.0)then
            if((id(1)*helicity(1)).le.0d0)then
-             current1=(Vcurrent1-Acurrent1)/2d0*gFFW*CKM(id(1),id(2))/dsqrt(ScaleFactor(id(1),id(2)))
+             current1=(Vcurrent1-Acurrent1)/2d0*gFFW*CKMbare(id(1),id(2))
            else
              current1=0d0
            endif

--- a/JHUGenerator/mod_Higgs.F90
+++ b/JHUGenerator/mod_Higgs.F90
@@ -622,14 +622,14 @@
    SUBROUTINE EvalAmp_H_FF(pin,mass_F,res)
    implicit none
    real(dp), intent(out) ::  res
-   complex(dp) :: amp
+   complex(dp) :: amp2
    real(dp), intent(in) :: pin(1:4,1:2),mass_F
    real(dp)             :: s12
 
       s12=2d0*(pin(1,1)*pin(1,2)-pin(2,1)*pin(2,2)-pin(3,1)*pin(3,2)-pin(4,1)*pin(4,2)) + 2d0*mass_F**2
-      amp =   2d0*s12*(kappa_tilde**2 + kappa**2) - 8d0*mass_F**2*kappa**2
-      amp = amp*mass_F**2/vev**2
-      res = cdabs(amp)
+      amp2 =   2d0*s12*(kappa_tilde**2 + kappa**2) - 8d0*mass_F**2*kappa**2
+      amp2 = amp2*mass_F**2/vev**2
+      res = cdabs(amp2)
 
    RETURN
    END SUBROUTINE

--- a/JHUGenerator/mod_Higgs.F90
+++ b/JHUGenerator/mod_Higgs.F90
@@ -622,12 +622,14 @@
    SUBROUTINE EvalAmp_H_FF(pin,mass_F,res)
    implicit none
    real(dp), intent(out) ::  res
+   complex(dp) :: amp
    real(dp), intent(in) :: pin(1:4,1:2),mass_F
    real(dp)             :: s12
 
       s12=2d0*(pin(1,1)*pin(1,2)-pin(2,1)*pin(2,2)-pin(3,1)*pin(3,2)-pin(4,1)*pin(4,2)) + 2d0*mass_F**2
-      res =   2d0*s12*(kappa_tilde**2 + kappa**2) - 8d0*mass_F**2*kappa**2
-      res=res*mass_F**2/vev**2
+      amp =   2d0*s12*(kappa_tilde**2 + kappa**2) - 8d0*mass_F**2*kappa**2
+      amp = amp*mass_F**2/vev**2
+      res = cdabs(amp)
 
    RETURN
    END SUBROUTINE

--- a/JHUGenerator/mod_HiggsJJ.F90
+++ b/JHUGenerator/mod_HiggsJJ.F90
@@ -2333,7 +2333,7 @@ module modHiggsJJ
           kfactor_w = 1.0_dp ! dsqrt(ScaleFactor(iSel,sSel)*ScaleFactor(jSel,rSel))
 
           !if(ZZ_fusion) then ! Special treatment for WW+ZZ interference, not included through phasespace
-          ckm_wfactor = CKM(iSel,sSel)*CKM(jSel,rSel)/dsqrt(ScaleFactor(iSel,sSel)*ScaleFactor(jSel,rSel))
+          ckm_wfactor = CKMbare(iSel,sSel)*CKMbare(jSel,rSel)
           !print *, "iSel, sSel: ",iSel," ",sSel, "; jSel, rSel: ",jSel," ",rSel, ", ckm: ",ckm_wfactor
           !endif
           !print *, "EvalAmp_WBFH_UnSymm_SA_Select_exact: isWW and is-jr"
@@ -2342,7 +2342,7 @@ module modHiggsJJ
           kw2 = 4
           kfactor_w = 1.0_dp ! dsqrt(ScaleFactor(iSel,rSel)*ScaleFactor(jSel,sSel))
 
-          ckm_wfactor = CKM(iSel,rSel)*CKM(jSel,sSel)/dsqrt(ScaleFactor(iSel,rSel)*ScaleFactor(jSel,sSel))
+          ckm_wfactor = CKMbare(iSel,rSel)*CKMbare(jSel,sSel)
           !print *, "iSel, rSel: ",iSel," ",rSel, "; jSel, sSel: ",jSel," ",sSel, ", ckm: ",ckm_wfactor
           !print *, "EvalAmp_WBFH_UnSymm_SA_Select_exact: isWW and ir-js"
        endif

--- a/JHUGenerator/mod_Parameters.F90
+++ b/JHUGenerator/mod_Parameters.F90
@@ -849,7 +849,7 @@ FUNCTION CKM(id1in,id2in)
 implicit none
 real(8) :: CKM
 integer :: id1in, id2in
-  CKM=CKMbare(id1in, id2in)*ScaleFactor(id1in,id2in)
+  CKM=CKMbare(id1in, id2in)*sqrt(ScaleFactor(id1in,id2in))
 END FUNCTION
 
 

--- a/JHUGenerator/mod_VHiggs.F90
+++ b/JHUGenerator/mod_VHiggs.F90
@@ -146,7 +146,7 @@ end subroutine EvalAmp_VHiggs
          !WH
          if((id(1)+id(2)).ne.0)then
            if((id(1)*helicity(1)).le.0d0)then
-             current1=(Vcurrent1-Acurrent1)/2d0*gFFW*CKM(id(1),id(2))/dsqrt(ScaleFactor(id(1),id(2)))
+             current1=(Vcurrent1-Acurrent1)/2d0*gFFW*CKMbare(id(1),id(2))
            else
              current1=0d0
            endif

--- a/circle.yml
+++ b/circle.yml
@@ -22,7 +22,7 @@ machine:
     ROOT_VERSIONSTRING: "${ROOT_VERSIONPART1}.${ROOT_VERSIONPART2}/${ROOT_VERSIONPART3}"
 
     REFERENCE_LHES_USERNAME: "hroskes"
-    REFERENCE_LHES_BUILD_NUMBER: "617"
+    REFERENCE_LHES_BUILD_NUMBER: "621"
     REFERENCE_LHES_FOLDER: "$(echo https://circleci.com/api/v1/project/$REFERENCE_LHES_USERNAME/JHUGen/$REFERENCE_LHES_BUILD_NUMBER/'artifacts/0/$CIRCLE_ARTIFACTS/reference')"
     REFERENCE_FILENAMES: "ggH_ZZ.lhe ggH_WW.lhe ggH_Zgamma.lhe ggH_gammagamma.lhe spin1_ZZ.lhe spin1_WW.lhe gg_spin2_ZZ.lhe qq_spin2_WW.lhe gg_spin2_Zgamma.lhe qq_spin2_gammagamma.lhe ZH_bb.lhe WH_Zgamma.lhe ee_gammaH_bb.lhe VBF_ZZ.lhe HJJ_WW.lhe HJ_gammagamma.lhe ttH_tautau.lhe bbH_tautau.lhe tqH_110.lhe tqH_111.lhe tqH_112.lhe tqH_113.lhe tqH_114.lhe"
 
@@ -307,7 +307,7 @@ test:
 
     #generate with 0 interference and make plots
     #this is only done when the reference comparison fails
-    #in that case the ME is the same, so no need to spend time making plots, they already exist
+    #if it succeeds the ME is the same, so no need to spend time making plots, they already exist
     #  in the run that produced the reference
     #this can take a good 2 hours
     - if [ -f ~/reference_failed ]; then ./JHUGen PDFSet=3 VegasNc0=1000000 VegasNc2=10000 Interf=0 DataFile=$CIRCLE_ARTIFACTS/ggH/SM; fi

--- a/circle.yml
+++ b/circle.yml
@@ -22,7 +22,7 @@ machine:
     ROOT_VERSIONSTRING: "${ROOT_VERSIONPART1}.${ROOT_VERSIONPART2}/${ROOT_VERSIONPART3}"
 
     REFERENCE_LHES_USERNAME: "hroskes"
-    REFERENCE_LHES_BUILD_NUMBER: "609"
+    REFERENCE_LHES_BUILD_NUMBER: "617"
     REFERENCE_LHES_FOLDER: "$(echo https://circleci.com/api/v1/project/$REFERENCE_LHES_USERNAME/JHUGen/$REFERENCE_LHES_BUILD_NUMBER/'artifacts/0/$CIRCLE_ARTIFACTS/reference')"
     REFERENCE_FILENAMES: "ggH_ZZ.lhe ggH_WW.lhe ggH_Zgamma.lhe ggH_gammagamma.lhe spin1_ZZ.lhe spin1_WW.lhe gg_spin2_ZZ.lhe qq_spin2_WW.lhe gg_spin2_Zgamma.lhe qq_spin2_gammagamma.lhe ZH_bb.lhe WH_Zgamma.lhe ee_gammaH_bb.lhe VBF_ZZ.lhe HJJ_WW.lhe HJ_gammagamma.lhe ttH_tautau.lhe bbH_tautau.lhe tqH_110.lhe tqH_111.lhe tqH_112.lhe tqH_113.lhe tqH_114.lhe"
 


### PR DESCRIPTION
tests should succeed now (but Ulascan please check that the convention is correct that ScaleFactor should be sqrted as it was before)