### PR TITLE
Added option to switch coupling convention

### DIFF
--- a/JHUGenLexicon/src/JHUGenLexiconOptionParser.cc
+++ b/JHUGenLexicon/src/JHUGenLexiconOptionParser.cc
@@ -78,6 +78,7 @@ void JHUGenLexiconOptionParser::interpretOption(std::string const& wish, std::st
   else if (wish=="HW_couplings_only"){flags[wish] = false; castStringToValue(value, flags[wish]); }
   else if (wish=="HZ_couplings_only"){flags[wish] = false; castStringToValue(value, flags[wish]); }
   else if (wish=="include_delta"){flags[wish] = false; castStringToValue(value, flags[wish]); }
+  else if (wish=="convention"){flags[wish] = false; castStringToValue(value, flags[wish]); }
   // Parameters come next, check if a comma is not found to assign them
   else if (value.find(",")==std::string::npos) parameters[wish] = stod(value);
 
@@ -106,7 +107,8 @@ void JHUGenLexiconOptionParser::printOptionsHelp(bool command_fail)const{
   cout << "- custodial_symmetry: set delta_m = 0 (Note: This also fixes delta_v in the Warsaw Basis)\n\n";  
   cout << "- HW_couplings_only: Only return HWW couplings. Only used for JHUGen_Amplitude Basis. Default is false.\n\n";
   cout << "- HZ_couplings_only: Only return HZZ, HZgamma and Hgammagamma couplings. Only used for JHUGen_Amplitude Basis. Default is false.\n\n";
-  cout << "- NOTE: HW_couplings_only and HZ_couplings_only does not affect the output of include_triple_quartic_gauge.";
+  cout << "- NOTE: HW_couplings_only and HZ_couplings_only does not affect the output of include_triple_quartic_gauge.\n\n";
+  cout << "- convention: Switch the relative sign on the Zgamma couplings.\n\n";
 
   cout << "- The format to set any parameter is [specifier]=[value].\n\n";
   cout << "- The format to set any coupling [specifier] to the complex number ([vRe], [vIm]) is [specifier]=[vRe],[vIm].\n\n";

--- a/JHUGenLexicon/src/JHUGenLexiconTranslator.cc
+++ b/JHUGenLexicon/src/JHUGenLexiconTranslator.cc
@@ -1794,6 +1794,7 @@ std::vector< std::pair<double, double> > JHUGenLexiconTranslator::getOrderedInpu
   bool useMCFMAtInput; getValueWithDefault<std::string, bool>(input_flags, "useMCFMAtInput", useMCFMAtInput, false);
   bool includeTripleGauge; getValueWithDefault<std::string, bool>(input_flags, "includeTripleGauge", includeTripleGauge, false);
   bool distinguish_HWWcouplings; getValueWithDefault<std::string, bool>(input_flags, "distinguish_HWWcouplings", distinguish_HWWcouplings, false);
+  bool convention; getValueWithDefault<std::string, bool>(input_flags, "convention", convention, false);
   double MZ; getValueWithDefault<std::string, double>(input_parameters, "MZ", MZ, DEFVAL_MZ);
   double MW; getValueWithDefault<std::string, double>(input_parameters, "MW", MW, DEFVAL_MW);
   double sw; getValueWithDefault<std::string, double>(input_parameters, "sw", sw, DEFVAL_SW);
@@ -1810,7 +1811,7 @@ std::vector< std::pair<double, double> > JHUGenLexiconTranslator::getOrderedInpu
   if (std::string(#NAME).find("ghzgs")!=std::string::npos && std::string(#NAME).find("prime2")!=std::string::npos){ res.at(coupl_##PREFIX##_##NAME).first *= std::pow(MZ/Lambda_zgs1, 2); res.at(coupl_##PREFIX##_##NAME).second *= std::pow(MZ/Lambda_zgs1, 2); } \
   else if (std::string(#NAME).find("ghz")!=std::string::npos && std::string(#NAME).find("prime2")!=std::string::npos){ res.at(coupl_##PREFIX##_##NAME).first *= std::pow(MZ/Lambda_z1, 2); res.at(coupl_##PREFIX##_##NAME).second *= std::pow(MZ/Lambda_z1, 2); } \
   else if (std::string(#NAME).find("ghw")!=std::string::npos && std::string(#NAME).find("prime2")!=std::string::npos){ res.at(coupl_##PREFIX##_##NAME).first *= std::pow(MW/Lambda_w1, 2); res.at(coupl_##PREFIX##_##NAME).second *= std::pow(MW/Lambda_w1, 2); } \
-  //if (std::string(#NAME).find("dFour_Z")!=std::string::npos){ res.at(coupl_##PREFIX##_##NAME).first *= std::pow(cw/sw, 1.0); res.at(coupl_##PREFIX##_##NAME).second *= std::pow(cw/sw,1.0); }
+  if (convention && ((std::string(#NAME).find("ghzgs2")!=std::string::npos) || (std::string(#NAME).find("ghzgs4")!=std::string::npos) || (std::string(#NAME).find("Cza")!=std::string::npos) || (std::string(#NAME).find("tCza")!=std::string::npos))){ res.at(coupl_##PREFIX##_##NAME).first *= -1.0; res.at(coupl_##PREFIX##_##NAME).second *= -1.0; }
   switch (basis_input){
   case bAmplitude_JHUGen:
   {
@@ -1858,10 +1859,12 @@ void JHUGenLexiconTranslator::interpretOutputCouplings(
   std::unordered_map<std::string, double> const& input_parameters,
   std::vector< std::pair<double, double> >& output_vector
 ){
+  auto const& basis_input = opts.getInputBasis();
   bool useMCFMAtOutput; getValueWithDefault<std::string, bool>(input_flags, "useMCFMAtOutput", useMCFMAtOutput, false);
   bool include_triple_quartic_gauge; getValueWithDefault<std::string, bool>(input_flags, "include_triple_quartic_gauge", include_triple_quartic_gauge, false);
   bool HW_couplings_only; getValueWithDefault<std::string, bool>(input_flags, "HW_couplings_only", HW_couplings_only, false);
   bool HZ_couplings_only; getValueWithDefault<std::string, bool>(input_flags, "HZ_couplings_only", HZ_couplings_only, false);
+  bool convention; getValueWithDefault<std::string, bool>(input_flags, "convention", convention, false);
   double MZ; getValueWithDefault<std::string, double>(input_parameters, "MZ", MZ, DEFVAL_MZ);
   double MW; getValueWithDefault<std::string, double>(input_parameters, "MW", MW, DEFVAL_MW);
   double Lambda_z1; getValueWithDefault<std::string, double>(input_parameters, "Lambda_z1", Lambda_z1, DEFVAL_LAMBDA_VI);
@@ -1872,7 +1875,8 @@ void JHUGenLexiconTranslator::interpretOutputCouplings(
   if (std::string(#NAME).find("ghzgs")!=std::string::npos && std::string(#NAME).find("prime2")!=std::string::npos){ output_vector.at(coupl_##PREFIX##_##NAME).first /= std::pow(MZ/Lambda_zgs1, 2); output_vector.at(coupl_##PREFIX##_##NAME).second /= std::pow(MZ/Lambda_zgs1, 2); } \
   else if (std::string(#NAME).find("ghz")!=std::string::npos && std::string(#NAME).find("prime2")!=std::string::npos){ output_vector.at(coupl_##PREFIX##_##NAME).first /= std::pow(MZ/Lambda_z1, 2); output_vector.at(coupl_##PREFIX##_##NAME).second /= std::pow(MZ/Lambda_z1, 2); } \
   else if (std::string(#NAME).find("ghw")!=std::string::npos && std::string(#NAME).find("prime2")!=std::string::npos){ output_vector.at(coupl_##PREFIX##_##NAME).first /= std::pow(MW/Lambda_w1, 2); output_vector.at(coupl_##PREFIX##_##NAME).second /= std::pow(MW/Lambda_w1, 2); } \
-  result_couplings[#NAME] = output_vector.at(coupl_##PREFIX##_##NAME);
+  else if (basis_input == bWarsawBasis && convention && ((std::string(#NAME).find("ghzgs2")!=std::string::npos) || (std::string(#NAME).find("ghzgs4")!=std::string::npos) || (std::string(#NAME).find("Cza")!=std::string::npos) || (std::string(#NAME).find("tCza")!=std::string::npos))){ output_vector.at(coupl_##PREFIX##_##NAME).first *= -1.0; output_vector.at(coupl_##PREFIX##_##NAME).second *= -1.0; } \
+  result_couplings[#NAME] = output_vector.at(coupl_##PREFIX##_##NAME);  
   switch (basis_output){
     case bAmplitude_JHUGen:
     {


### PR DESCRIPTION
Added an option in Lexicon to switch the relative sign on the Zgamma couplings. This is needed to relate coupling to different generators etc. 