### PR TITLE
Custom Higgs Width functionality for MCFM

### DIFF
--- a/MCFM-JHUGen/src/Inc/spinzerohiggs_anomcoupl.f
+++ b/MCFM-JHUGen/src/Inc/spinzerohiggs_anomcoupl.f
@@ -35,7 +35,7 @@ c---- NOTE: Please add new future couplings in the same order for both declarati
       double precision Lambda_w12,Lambda_w22,Lambda_w32,Lambda_w42
       double precision Lambda_w10,Lambda_w20,Lambda_w30,Lambda_w40
 
-      double precision h2mass,h2width
+      double precision h2mass,h2width,custom_hwidth
 
       double precision Lambda2BSM,Lambda2_Q
       double precision Lambda2_zgs1
@@ -136,7 +136,7 @@ c---- NOTE: Please add new future couplings in the same order for both declarati
      & Lambda_w12,Lambda_w22,Lambda_w32,Lambda_w42,
      & Lambda_w10,Lambda_w20,Lambda_w30,Lambda_w40,
 
-     & h2mass,h2width,
+     & h2mass,h2width,custom_hwidth,
 
      & Lambda2BSM,Lambda2_Q,
      & Lambda2_zgs1,

--- a/MCFM-JHUGen/src/Need/higgsp.f
+++ b/MCFM-JHUGen/src/Need/higgsp.f
@@ -4,6 +4,7 @@ C  interpolating the Spira tables br.sm1 br.sm2
 C  Other branching ratios could be added.
       implicit none
       include 'masses.f'
+      include 'spinzerohiggs_anomcoupl.f'
       !include 'first.f'
       logical first_higgsp
       data first_higgsp/.true./
@@ -58,7 +59,11 @@ C  Other branching ratios could be added.
       zgambr=brzgam(nlo)+(htemp-nlo)*(brzgam(nlo+1)-brzgam(nlo))
       wwbr=brww(nlo)+(htemp-nlo)*(brww(nlo+1)-brww(nlo))
       zzbr=brzz(nlo)+(htemp-nlo)*(brzz(nlo+1)-brzz(nlo))
-      hwidth=width(nlo)+(htemp-nlo)*(width(nlo+1)-width(nlo))
+      if(custom_hwidth.eq.-1) then
+          hwidth=width(nlo)+(htemp-nlo)*(width(nlo+1)-width(nlo))
+      else
+          hwidth=custom_hwidth
+      endif
       return
 
  44   continue

--- a/MCFM-JHUGen/src/Need/higgsw.f
+++ b/MCFM-JHUGen/src/Need/higgsw.f
@@ -3,13 +3,18 @@
       include 'constants.f'
       include 'ewcouple.f'
       include 'masses.f'
+      include 'spinzerohiggs_anomcoupl.f'
       double precision wff,mfsq,br
 c-----approximate form for the width of the standard model higgs
 c-----valid for low masses
       wff(mfsq)=dsqrt(2d0)/8d0/pi*gf*hmass*mfsq
      & *(1d0-4d0*mfsq/hmass**2)**1.5d0
-
-      hwidth=3d0*(wff(mbsq)+wff(mcsq))+wff(mtausq)
+      
+      if(custom_hwidth.ne.-1) then
+            hwidth = custom_hwidth
+      else
+            hwidth=3d0*(wff(mbsq)+wff(mcsq))+wff(mtausq)
+      endif
       write(6,*) 'hmass,hwidth',hmass,hwidth
       write(6,*) 'mtausq,mcsq,mbsq',mtausq,mcsq,mbsq
       write(6,*)

--- a/MCFM-JHUGen/src/User/mdata.f
+++ b/MCFM-JHUGen/src/User/mdata.f
@@ -193,6 +193,7 @@ c     MARKUS: anomalous couplings for 2nd resonance
 c     Mass and width for second resonance
       data h2mass  /-1d0/ ! -1 disables the resonance
       data h2width /0d0/
+      data custom_hwidth /-1d0/ ! -1 uses the default hwidth value from input.dat
 
 c     Hgg and Hff anomalous couplings
       data kappa2_top / (0d0,0d0) /


### PR DESCRIPTION
When doing the widthscheme stuff, I forgot to put in the method that is used to actually change the width itself. Currently - the width is edited through a factor multiplied by the "normal" "higgs: width, if I understand correctly. 

This change makes the "higgs" width just a value that is input into User/mdata.f. The default value of -1 will simply use the width calculation from before.