### PR TITLE
A new Factorization Scheme sampling from a uniform distribution between 2 numbers

### DIFF
--- a/JHUGenerator/main.F90
+++ b/JHUGenerator/main.F90
@@ -1371,6 +1371,7 @@ type(SaveValues) :: tosave, oldsavevalues
       (MuFacMultiplier.le.0d0) .or. (MuRenMultiplier.le.0d0)                                  &
     ) call Error("The renormalization or factorization scheme is invalid, or the scale multiplier to either is not positive.")
     if( SetFacScheme .and. (FacScheme.eq.12) .and. (.not.SetSchemeBounds)) call Error("If you want to set a bounded scale, please set the bounds!")
+    if( SetFacScheme .and. (FacScheme.eq.12) .and. (CustomLowerScaleBound > CustomUpperScaleBound)) call Error("Bounds must be set as lower<=upper!")
     if( (SetFacScheme.neqv.SetMuFacMultiplier).and.(.not.FacScheme.eq.12) ) call Error("If you want to set the factorization scale, please set both the scheme (FacScheme) and the multiplier (MuFacMultiplier)")
     if( (SetRenScheme.neqv.SetMuRenMultiplier).and.(.not.FacScheme.eq.12) ) call Error("If you want to set the renormalization scale, please set both the scheme (RenScheme) and the multiplier (MuRenMultiplier)")
     !DecayModes

--- a/JHUGenerator/main.F90
+++ b/JHUGenerator/main.F90
@@ -323,7 +323,9 @@ subroutine InitProcessScaleSchemes() ! If schemes are set to default, reset to t
             Process.eq. 2      & !- ggH spin-2
          ) .and. (             &
             (abs(FacScheme).ne.kRenFacScheme_mhstar) .or. (abs(RenScheme).ne.kRenFacScheme_mhstar)      &
-         )                     &
+         ) .and. (                     &
+            FacScheme.ne.kRenFacScheme_custom_scale     &
+         )                             &
       ) call Error("Invalid scheme for the H+0J processes. Choose a different renormalization or factorization scheme.")
 
 
@@ -402,7 +404,7 @@ implicit none
 character :: arg*(500)
 integer :: NumArgs,NArg
 logical :: help, PrintVersion, PrintHeader, DryRun, success, SetLastArgument, interfSet, ignoreRunningWidthResonanceCheck
-logical :: SetRenScheme, SetMuRenMultiplier, SetFacScheme, SetMuFacMultiplier
+logical :: SetRenScheme, SetMuRenMultiplier, SetFacScheme, SetMuFacMultiplier, SetSchemeBounds
 logical :: SetMReso, SetGaReso, SetMReso2, SetGaReso2
 logical :: SetAnomalousSpin0gg, Setghg2, SetAnomalousSpin0VV, Setghz1
 logical :: SetZZcoupling, SetZZprimecoupling, SetZprimeZprimecoupling
@@ -452,7 +454,7 @@ type(SaveValues) :: tosave, oldsavevalues
    SetMuRenMultiplier = .false.
    SetFacScheme = .false.
    SetRenScheme = .false.
-
+   SetSchemeBounds = .false.
    SetMReso=.false.
    SetGaReso=.false.
    SetMReso2=.false.
@@ -605,6 +607,7 @@ type(SaveValues) :: tosave, oldsavevalues
     call ReadCommandLineArgument(arg, "RenScheme", success, RenScheme, success2=SetRenScheme, tosave=tosave)
     call ReadCommandLineArgument(arg, "MuFacMultiplier", success, MuFacMultiplier, success2=SetMuFacMultiplier, tosave=tosave)
     call ReadCommandLineArgument(arg, "MuRenMultiplier", success, MuRenMultiplier, success2=SetMuRenMultiplier, tosave=tosave)
+    call ReadCommandLineArgument_2_tuple_real8(arg, "MuFacBounds", success, CustomLowerScaleBound, CustomUpperScaleBound, success2=SetSchemeBounds, tosave=tosave)
     call ReadCommandLineArgument(arg, "TopDK", success, TopDecays, tosave=tosave)
     call ReadCommandLineArgument(arg, "TauDK", success, TauDecays, tosave=tosave)
     call ReadCommandLineArgument(arg, "HbbDK", success, H_DK, tosave=tosave)
@@ -1365,9 +1368,9 @@ type(SaveValues) :: tosave, oldsavevalues
       (FacScheme .eq. -kRenFacScheme_minpTj) .or. (RenScheme .eq. -kRenFacScheme_minpTj) .or. &
       (MuFacMultiplier.le.0d0) .or. (MuRenMultiplier.le.0d0)                                  &
     ) call Error("The renormalization or factorization scheme is invalid, or the scale multiplier to either is not positive.")
-    if( SetFacScheme.neqv.SetMuFacMultiplier ) call Error("If you want to set the factorization scale, please set both the scheme (FacScheme) and the multiplier (MuFacMultiplier)")
-    if( SetRenScheme.neqv.SetMuRenMultiplier ) call Error("If you want to set the renormalization scale, please set both the scheme (RenScheme) and the multiplier (MuRenMultiplier)")
-
+    if( SetFacScheme .and. (FacScheme.eq.12) .and. (.not.SetSchemeBounds)) call Error("If you want to set a bounded scale, please set the bounds!")
+    if( (SetFacScheme.neqv.SetMuFacMultiplier).and.(.not.FacScheme.eq.12) ) call Error("If you want to set the factorization scale, please set both the scheme (FacScheme) and the multiplier (MuFacMultiplier)")
+    if( (SetRenScheme.neqv.SetMuRenMultiplier).and.(.not.FacScheme.eq.12) ) call Error("If you want to set the renormalization scale, please set both the scheme (RenScheme) and the multiplier (MuRenMultiplier)")
     !DecayModes
 
     if( ConvertLHEFile ) then

--- a/JHUGenerator/main.F90
+++ b/JHUGenerator/main.F90
@@ -248,6 +248,10 @@ subroutine InitProcessScaleSchemes() ! If schemes are set to default, reset to t
          endif
       endif
 
+      if(FacScheme.eq.kRenFacScheme_custom_scale) then !If you are using a custom scale there is no need for other checks
+        return
+     endif
+
       ! H+2j MEs
       if( &
          (                     &
@@ -323,9 +327,7 @@ subroutine InitProcessScaleSchemes() ! If schemes are set to default, reset to t
             Process.eq. 2      & !- ggH spin-2
          ) .and. (             &
             (abs(FacScheme).ne.kRenFacScheme_mhstar) .or. (abs(RenScheme).ne.kRenFacScheme_mhstar)      &
-         ) .and. (                     &
-            FacScheme.ne.kRenFacScheme_custom_scale     &
-         )                             &
+         )                     &
       ) call Error("Invalid scheme for the H+0J processes. Choose a different renormalization or factorization scheme.")
 
 

--- a/JHUGenerator/makefile
+++ b/JHUGenerator/makefile
@@ -6,7 +6,7 @@ MELADir = ""
 MELAFortranDir = ""
 MELADataDir = ""
 MELALibDir = ""
-MCFMLib = mcfm_708
+MCFMLib = mcfm_709
 PDFDir = $(Here)/pdfs
 VegasDir = $(Here)/vegas
 CollierDir = $(Here)/../lib/COLLIER/
@@ -25,7 +25,7 @@ UseLHAPDF=No
 #          LHAPDF_DATA_PATH=/.../LHAPDF-x.y.z/share/LHAPDF/:${LHAPDF_DATA_PATH}
 
 ## link MCFM libraries from MELA
-linkMELA = No
+linkMELA = Yes
 # remember to export
 #          LD_LIBRARY_PATH=/.../MELA/data/$SCRAM_ARCH/:${LD_LIBRARY_PATH}
 

--- a/JHUGenerator/makefile
+++ b/JHUGenerator/makefile
@@ -25,7 +25,7 @@ UseLHAPDF=No
 #          LHAPDF_DATA_PATH=/.../LHAPDF-x.y.z/share/LHAPDF/:${LHAPDF_DATA_PATH}
 
 ## link MCFM libraries from MELA
-linkMELA = Yes
+linkMELA = No
 # remember to export
 #          LD_LIBRARY_PATH=/.../MELA/data/$SCRAM_ARCH/:${LD_LIBRARY_PATH}
 

--- a/JHUGenerator/mod_CommandLine.F90
+++ b/JHUGenerator/mod_CommandLine.F90
@@ -431,6 +431,67 @@ real(8) :: dest_store
 
 end subroutine ReadCommandLineArgument_real8
 
+subroutine ReadCommandLineArgument_2_tuple_real8(argument, argumentname, success, dest, dest2, SetLastArgument, success2, success3, success4, success5, success6, checkdestchange, multiply, tosave)
+  implicit none
+  character(len=*) :: argument, argumentname
+  real(8), intent(inout) :: dest, dest2
+  logical, intent(inout) :: success
+  logical, optional, intent(inout) :: SetLastArgument, success2, success3, success4, success5, success6
+  logical, optional, intent(in) :: checkdestchange
+  type(SaveValues), optional :: tosave
+  real(8), optional, intent(in) :: multiply
+  logical :: successval
+  integer :: length
+  real(8) :: lower, upper
+  real(8) :: dest_store, dest_store2
+  
+      successval = .true.
+      dest_store = dest
+      dest_store2 = dest2
+  
+      if (present(SetLastArgument)) SetLastArgument=.false.
+  
+      length=len(trim(argumentname))
+  
+      if( argument(1:length+1) .eq. trim(argumentname)//"=" ) then
+          if( Index(argument(length+2:len(trim(argument))),",").eq.0 &
+         .and. Index(argument(length+2:len(trim(argument)))," ").eq.0 ) then
+              print *, "Argument ", argumentname, " is a tuple consisting of an upper and lower bound for a range."
+              print *, "Example syntax for arguments:"
+              print *, "      ", argumentname, "=1,2"
+              print *, "   or ", argumentname, "=1.0d0,2.0d0"
+              print *, "for a range of [1,2]"
+              stop 1
+          endif
+          read(argument(length+2:len(argument)), *) lower, upper
+          
+          dest = lower
+          dest2 = upper
+
+          if (present(multiply)) then 
+            dest = dest*multiply
+            dest2 = dest2*multiply
+          endif
+          ! Checkdestchange after all multiplications are done!
+          if (present(checkdestchange)) then
+             !print *, argumentname,": checkdestchange, dest_store, dest",checkdestchange,dest_store,dest
+             successval = (.not. checkdestchange .or. dest.ne.dest_store).and.(.not. checkdestchange .or. dest2.ne.dest_store2)
+          endif
+          if (present(SetLastArgument)) SetLastArgument=successval
+          if (present(success2)) success2=success2 .or. successval
+          if (present(success3)) success3=success3 .or. successval
+          if (present(success4)) success4=success4 .or. successval
+          if (present(success5)) success5=success5 .or. successval
+          if (present(success6)) success6=success6 .or. successval
+
+          if (successval .and. present(tosave)) then
+            call tosave%savevalue_real8(argumentname, dest)
+            call tosave%savevalue_real8(argumentname, dest2)
+          endif
+          success = .true.
+      endif
+  
+  end subroutine ReadCommandLineArgument_2_tuple_real8
 
 subroutine ReadCommandLineArgument_complex8(argument, argumentname, success, dest, SetLastArgument, success2, success3, success4, success5, success6, checkdestchange, multiply, multiplyreal, tosave)
 implicit none

--- a/JHUGenerator/mod_Kinematics.F90
+++ b/JHUGenerator/mod_Kinematics.F90
@@ -7791,7 +7791,6 @@ integer idx,ip
       call random_number(Mu_Fact)
       Mu_Fact = (CustomUpperScaleBound - CustomLowerScaleBound)*Mu_Fact + CustomLowerScaleBound
       Mu_Fact = Mu_Fact/100 !correction to make sure that you are operating in single GeVs, not hundreds of GeV
-      ! PRINT *, "MU_FACT=", Mu_Fact
    else
       call Error("This should never be able to happen.")
    endif

--- a/JHUGenerator/mod_Kinematics.F90
+++ b/JHUGenerator/mod_Kinematics.F90
@@ -7787,6 +7787,11 @@ integer idx,ip
       Mu_Fact = maxpTjet
    elseif(FacScheme .eq. kRenFacScheme_minpTj) then
       Mu_Fact = minpTjet
+   elseif(FacScheme .eq. kRenFacScheme_custom_scale) then
+      call random_number(Mu_Fact)
+      Mu_Fact = (CustomUpperScaleBound - CustomLowerScaleBound)*Mu_Fact + CustomLowerScaleBound
+      Mu_Fact = Mu_Fact/100 !correction to make sure that you are operating in single GeVs, not hundreds of GeV
+      ! PRINT *, "MU_FACT=", Mu_Fact
    else
       call Error("This should never be able to happen.")
    endif

--- a/JHUGenerator/mod_Parameters.F90
+++ b/JHUGenerator/mod_Parameters.F90
@@ -18,7 +18,7 @@ integer, public :: Collider,PChannel,Process,DecayMode1,DecayMode2,TopDecays,Tau
 integer, public :: VegasIt1,VegasNc0,VegasNc1,VegasNc2,PMZZEvals
 real(8), public :: Collider_Energy
 integer, public :: FacScheme,RenScheme
-real(8), public :: MuFacMultiplier,MuRenMultiplier
+real(8), public :: MuFacMultiplier,MuRenMultiplier,CustomUpperScaleBound, CustomLowerScaleBound
 integer, public :: VegasIt1_default,VegasNc0_default,VegasNc1_default,VegasNc2_default
 integer, public :: NumHistograms
 integer, public :: RequestNLeptons(1:2) = -1
@@ -41,7 +41,8 @@ integer, public, parameter :: kRenFacScheme_mj_mhstar=8
 integer, public, parameter :: kRenFacScheme_mj=9
 integer, public, parameter :: kRenFacScheme_maxpTj=10
 integer, public, parameter :: kRenFacScheme_minpTj=11
-integer, public, parameter :: nRenFacSchemes=12
+integer, public, parameter :: kRenFacScheme_custom_scale=12
+integer, public, parameter :: nRenFacSchemes=13
 integer, public, parameter :: maxpart = 30
 integer, public, parameter :: NMAXCHANNELS=200 ! Maximum 250 from vegas_common xi dimensions
 integer(8), public :: EvalCounter=0

--- a/MCFM-JHUGen/compile.sh
+++ b/MCFM-JHUGen/compile.sh
@@ -19,7 +19,7 @@ if [[ -z "${SCRAM_ARCH+x}" ]];then
     export SCRAM_ARCH="slc7_amd64_gcc820"
   fi
 fi
-LIB=libmcfm_708.so
+LIB=libmcfm_709.so
 
 for aDir in QCDLoop/ff QCDLoop/ql QCDLoop TensorReduction/ov TensorReduction/pv TensorReduction/ov TensorReduction/recur/smallY TensorReduction/recur/smallP TensorReduction/recur/smallG TensorReduction/recur/smallF TensorReduction/recur
 do

--- a/MCFM-JHUGen/makefile
+++ b/MCFM-JHUGen/makefile
@@ -882,6 +882,7 @@ scaleset_m34sqsumptjsq.o \
 scaleset_ptphoton.o \
 scaleset_HT.o \
 scaleset_ddis.o \
+scaleset_randrange.o \
 sethparams.o \
 setmb_msbar.o \
 setrunname.o \
@@ -1332,6 +1333,7 @@ jetlabel_to_stdhep.o \
 jetreorder.o \
 mcfm_getunweighted.o \
 mdata.o \
+fac_range.o \
 miscclust.o \
 nplotter.o \
 nplotter_4ftwdk.o \

--- a/MCFM-JHUGen/src/Inc/facscale_range.f
+++ b/MCFM-JHUGen/src/Inc/facscale_range.f
@@ -1,0 +1,3 @@
+      double precision facscale_low
+      double precision facscale_high
+      common/facscale_range/facscale_low,facscale_high

--- a/MCFM-JHUGen/src/Need/scaleset.f
+++ b/MCFM-JHUGen/src/Need/scaleset.f
@@ -41,14 +41,20 @@ c--- routines for exact definitions of the scales.
         call scaleset_ddis(p,mu0)
       elseif (dynstring .eq. 's-hat') then
         call scaleset_shat(p,mu0)
+      elseif (dynstring .eq. 'rand') then
+        call scaleset_randrange(p,mu0)
       else
         write(6,*) 'Dynamic scale choice not recognized'
         write(6,*) '   dynamicscale = ',dynstring
         stop
       endif
       
+      if (dynstring .eq. 'rand') then
+        facscale=mu0
+      else
+        facscale=fscalestart*mu0
+      endif
       scale=rscalestart*mu0
-      facscale=fscalestart*mu0
       frag_scale=frag_scalestart*mu0
           
       if (first) then

--- a/MCFM-JHUGen/src/Need/scaleset_randrange.f
+++ b/MCFM-JHUGen/src/Need/scaleset_randrange.f
@@ -1,0 +1,30 @@
+      subroutine scaleset_randrange(p,mu0)
+c--- subroutine to calculate dynamic scale equal to
+c--- invariant mass of particles 3, 4, 5 and 6
+      implicit none
+      include 'constants.f'
+      include 'process.f'
+      include 'facscale.f'
+      include 'facscale_range.f'
+      double precision p(mxpart,4),mu0
+      if(facscale_high.lt.facscale_low) then
+        write(6,*)'high scale bound must be < low!'
+        write(6,*)'Please edit factorization_range.f'
+        stop
+      endif
+      if(
+     &   (case .eq. 'HZZ_4l') .or.
+     &   (case .eq. 'HmZZ4l') .or.
+     &   (case .eq. 'ggZZ4l') .or.
+     &   (case .eq. 'ZZlept')
+     & ) then
+        call random_number(mu0)
+        mu0 = (facscale_high - facscale_low)*mu0 + facscale_low
+      else
+        write(6,*)'dynamicscale rand not supported for this process.'
+        stop
+      endif
+
+      return
+      end
+

--- a/MCFM-JHUGen/src/User/fac_range.f
+++ b/MCFM-JHUGen/src/User/fac_range.f
@@ -1,0 +1,11 @@
+************************************************************************
+*     Range for the dynamic factorization scale "rand"                 *
+*      low must be <= high                                             *
+************************************************************************
+      block data fac_range
+      implicit none
+      include 'facscale_range.f'
+      data facscale_low/10d0/
+      data facscale_high/40d0/
+      end
+************************************************************************

--- a/Manual/manJHUGenerator.tex
+++ b/Manual/manJHUGenerator.tex
@@ -768,7 +768,7 @@ need to be set and are common to both resonances. The masses modifying the third
 \subsubsection{Renormalization and factorization scales}
 \begin{itemize}
 	\item \verb|FacScheme|, \verb|MuFacMultiplier|, and \verb|RenScheme|, \verb|MuRenMultiplier|: There are currently 10 different schemes, which set the basis of the scale up to the scale multiplier. A postive integer uses running scales per event whereas a negative one uses a fixed scale, and \verb|MuFacMultiplier| and \verb|MuRenMultiplier| determine the scale multipliers for the factorization and renormalization scales, respectively.
-  \item \verb|SetSchemeBounds|: Setting the Factorization Scheme to 12 is a special case - you will also need to set \verb|SetSchemeBounds| as a range between a lower and upper bound
+  \item \verb|MuFacBounds|: Setting the Factorization Scheme to 12 is a special case - you will also need to set \verb|MuFacBounds| as a range between a lower and upper bound
 	\begin{itemize}
 		\item $\pm0$: $\mu_{F,\,R}$ are set to the default values of each process. The command line values of \verb|MuFacMultiplier| and \verb|MuRenMultiplier| are disregarded.
 		\item $\pm1$: $\mu_{F,\,R} \propto \sqrt{q^2_H}$ if the scheme number is positive, or $\mu_{F,\,R} \propto m_H$ if the scheme number is negative. $+1$ is the default value for \verb|Process| 0, 1 and 2 with scale multiplier $0.5$, and  $-1$ is the default value for \verb|Process| 50, 60, 61 and 62 with scale multiplier $1$.
@@ -782,7 +782,7 @@ need to be set and are common to both resonances. The masses modifying the third
 		\item $\pm9$: If the scheme number is positive, $\mu_{F,\,R} \propto \sqrt{q^2_{J}}$, where $J$ is the more massive associated particle. If the scheme number is negative and the matrix element treats an associated particle as massive (\eg $t$ in $t+H$), $\mu_{F,\,R} \propto m_{J}$.
 		\item $+10$: $\mu_{F,\,R} \propto p_T^J$, where $J$ is the hardest associated jet.
 		\item $+11$: $\mu_{F,\,R} \propto p_T^J$, where $J$ is the softest associated jet.
-    \item $+12$: This sets the range between the two values given in \verb|SetSchemeBounds|. The factorization scale will be pulled from a uniform random distribution between in the range [lower, upper)
+    \item $+12$: This sets the range between the two values given in \verb|MuFacBounds|. The factorization scale will be pulled from a uniform random distribution between in the range [lower, upper)
 	\end{itemize}
 \end{itemize}
 \subsubsection{Lepton and jet filter}

--- a/Manual/manJHUGenerator.tex
+++ b/Manual/manJHUGenerator.tex
@@ -767,8 +767,9 @@ need to be set and are common to both resonances. The masses modifying the third
 \end{itemize}
 \subsubsection{Renormalization and factorization scales}
 \begin{itemize}
-	\item \verb|FacScheme|, \verb|MuFacMultiplier|, and \verb|RenScheme|, \verb|MuRenMultiplier|: There are currently 10 different schemes, which set the basis of the scale up to the scale multiplier. A postive integer uses running scales per event whereas a negative one uses a fixed scale, and \verb|MuFacMultiplier| and \verb|MuRenMultiplier| determine the scale multipliers for the factorization and renormalization scales, respectively.
-  \item \verb|MuFacBounds|: Setting the Factorization Scheme to 12 is a special case - you will also need to set \verb|MuFacBounds| as a range between a lower and upper bound
+	\item \verb|FacScheme|, \verb|MuFacMultiplier|, and \verb|RenScheme|, \verb|MuRenMultiplier|: There are currently 10 different schemes, which set the basis of the scale up to the scale multiplier. A positive integer uses running scales per event whereas a negative one uses a fixed scale, and \verb|MuFacMultiplier| and \verb|MuRenMultiplier| determine the scale multipliers for the factorization and renormalization scales, respectively.
+  \item \verb|MuFacBounds|: Setting the Factorization Scheme to 12 is a special case - you will also need to set \verb|MuFacBounds| as a range between a lower and upper bound. 
+  FacScheme 12 should not be used unless the user knows \textit{precisely} what is desired, as this scheme creates random values of the factorization scale which may become not reproducible with MELA when used in PDF sets, unless the scale is read directly from the LHE file and is used to supply the scale to MELA.
 	\begin{itemize}
 		\item $\pm0$: $\mu_{F,\,R}$ are set to the default values of each process. The command line values of \verb|MuFacMultiplier| and \verb|MuRenMultiplier| are disregarded.
 		\item $\pm1$: $\mu_{F,\,R} \propto \sqrt{q^2_H}$ if the scheme number is positive, or $\mu_{F,\,R} \propto m_H$ if the scheme number is negative. $+1$ is the default value for \verb|Process| 0, 1 and 2 with scale multiplier $0.5$, and  $-1$ is the default value for \verb|Process| 50, 60, 61 and 62 with scale multiplier $1$.

--- a/Manual/manJHUGenerator.tex
+++ b/Manual/manJHUGenerator.tex
@@ -767,7 +767,8 @@ need to be set and are common to both resonances. The masses modifying the third
 \end{itemize}
 \subsubsection{Renormalization and factorization scales}
 \begin{itemize}
-	\item \verb|FacScheme|, \verb|MuFacMultiplier|, and \verb|RenScheme|, \verb|MuRenMultiplier|: There are currently 10 different schemes, which set the basis of the scale up to the scale multiplier. A postive integer uses running scales per event whereas a negative one uses a fixed scale, and \verb|MuFacMultiplier| and \verb|MuRenMultiplier| determine the scale multipliers for the factorization and renormalization scales, respectively:
+	\item \verb|FacScheme|, \verb|MuFacMultiplier|, and \verb|RenScheme|, \verb|MuRenMultiplier|: There are currently 10 different schemes, which set the basis of the scale up to the scale multiplier. A postive integer uses running scales per event whereas a negative one uses a fixed scale, and \verb|MuFacMultiplier| and \verb|MuRenMultiplier| determine the scale multipliers for the factorization and renormalization scales, respectively.
+  \item \verb|SetSchemeBounds|: Setting the Factorization Scheme to 12 is a special case - you will also need to set \verb|SetSchemeBounds| as a range between a lower and upper bound
 	\begin{itemize}
 		\item $\pm0$: $\mu_{F,\,R}$ are set to the default values of each process. The command line values of \verb|MuFacMultiplier| and \verb|MuRenMultiplier| are disregarded.
 		\item $\pm1$: $\mu_{F,\,R} \propto \sqrt{q^2_H}$ if the scheme number is positive, or $\mu_{F,\,R} \propto m_H$ if the scheme number is negative. $+1$ is the default value for \verb|Process| 0, 1 and 2 with scale multiplier $0.5$, and  $-1$ is the default value for \verb|Process| 50, 60, 61 and 62 with scale multiplier $1$.
@@ -781,6 +782,7 @@ need to be set and are common to both resonances. The masses modifying the third
 		\item $\pm9$: If the scheme number is positive, $\mu_{F,\,R} \propto \sqrt{q^2_{J}}$, where $J$ is the more massive associated particle. If the scheme number is negative and the matrix element treats an associated particle as massive (\eg $t$ in $t+H$), $\mu_{F,\,R} \propto m_{J}$.
 		\item $+10$: $\mu_{F,\,R} \propto p_T^J$, where $J$ is the hardest associated jet.
 		\item $+11$: $\mu_{F,\,R} \propto p_T^J$, where $J$ is the softest associated jet.
+    \item $+12$: This sets the range between the two values given in \verb|SetSchemeBounds|. The factorization scale will be pulled from a uniform random distribution between in the range [lower, upper)
 	\end{itemize}
 \end{itemize}
 \subsubsection{Lepton and jet filter}


### PR DESCRIPTION
This is a PR regarding an update necessary to match distributions when it comes to Pythia factorization schemes - we are putting into place the option to have a scheme where the factorization scale is a random number uniformly picked between two bounds [upper, lower). 

The changes include:

A new command line parser capable of reading in two real valued numbers (as opposed to a single complex one, which this parser was based off of)

A randomly sampled factorization scheme if you set FacScheme=12 and MuFacBounds=<lower>,<upper>

