### PR TITLE
changes to Ztt and Lexicon

### DIFF
--- a/JHUGenLexicon/src/JHUGenLexiconTranslator.cc
+++ b/JHUGenLexicon/src/JHUGenLexiconTranslator.cc
@@ -1872,6 +1872,8 @@ void JHUGenLexiconTranslator::interpretOutputCouplings(
   double Lambda_zgs1; getValueWithDefault<std::string, double>(input_parameters, "Lambda_zgs1", Lambda_zgs1, DEFVAL_LAMBDA_VI);
 #define COUPLING_COMMAND(NAME, PREFIX, DEFVAL) \
   if (useMCFMAtOutput && (std::string(#NAME).find("ghz")!=std::string::npos || std::string(#NAME).find("ghw")!=std::string::npos)){ output_vector.at(coupl_##PREFIX##_##NAME).first /= 2.; output_vector.at(coupl_##PREFIX##_##NAME).second /= 2.; } \
+  if (useMCFMAtOutput && (#NAME == "dZZWpWm")){ output_vector.at(coupl_##PREFIX##_##NAME).first /= 3.32545; } \
+  if (useMCFMAtOutput && (#NAME == "dZAWpWm")){ output_vector.at(coupl_##PREFIX##_##NAME).first /= 1.82358; } \
   if (std::string(#NAME).find("ghzgs")!=std::string::npos && std::string(#NAME).find("prime2")!=std::string::npos){ output_vector.at(coupl_##PREFIX##_##NAME).first /= std::pow(MZ/Lambda_zgs1, 2); output_vector.at(coupl_##PREFIX##_##NAME).second /= std::pow(MZ/Lambda_zgs1, 2); } \
   else if (std::string(#NAME).find("ghz")!=std::string::npos && std::string(#NAME).find("prime2")!=std::string::npos){ output_vector.at(coupl_##PREFIX##_##NAME).first /= std::pow(MZ/Lambda_z1, 2); output_vector.at(coupl_##PREFIX##_##NAME).second /= std::pow(MZ/Lambda_z1, 2); } \
   else if (std::string(#NAME).find("ghw")!=std::string::npos && std::string(#NAME).find("prime2")!=std::string::npos){ output_vector.at(coupl_##PREFIX##_##NAME).first /= std::pow(MW/Lambda_w1, 2); output_vector.at(coupl_##PREFIX##_##NAME).second /= std::pow(MW/Lambda_w1, 2); } \

--- a/MCFM-JHUGen/src/Inc/AnomZffCouplings.f
+++ b/MCFM-JHUGen/src/Inc/AnomZffCouplings.f
@@ -2,11 +2,12 @@
 
         double precision reZ,leZ,lnZ,rnZ
         double precision rquZ,lquZ,rqdZ,lqdZ 
-        double precision clanou,cranou,clanod,cranod
+        double precision clanou,cranou,clanod,cranod,clanot,cranot
 
         common/AnomZffCouplings/
      & AllowAnomalousZffCouplings,
 
      & reZ,leZ,lnZ,rnZ,
      & rquZ,lquZ,rqdZ,lqdZ,
-     & clanou,cranou,clanod,cranod
+     & clanou,cranou,clanod,cranod,
+     & clanot,cranot

--- a/MCFM-JHUGen/src/User/mdata.f
+++ b/MCFM-JHUGen/src/User/mdata.f
@@ -392,6 +392,11 @@ c     left handed Z couplings to neutrinos
 c     right handed Z couplings to neutrinos
       data rnZ / 0d0 / ! SM = 0 
 
+c     Anomalous Couplings for the Z to the top quark in production
+c     Note, these are called as shifts to SM values
+      data clanot / 0d0 / ! SM unshifted = 0.82039507607344309
+      data cranot / 0d0 / ! SM unshifted = -0.36558111377463703
+
 c     Anomalous Couplings for the Z to up type quarks in production 
 c     Note, these are called as shifts to SM values
       data clanou / 0d0 / ! SM = 0

--- a/MCFM-JHUGen/src/ZZ/getggZZamps.f
+++ b/MCFM-JHUGen/src/ZZ/getggZZamps.f
@@ -37,7 +37,7 @@ c--- expected to be unreliable, namely pt(Z)<ptZsafetycut set below
       include 'ewcharge.f'
       logical dolight,dobottom,dotop,ggZZuse6d
       integer h1,h2,h34,h56,up,dn,om,nu
-      double precision p(mxpart,4),cvec(2),cax(2),cl1(2),cl2(2),
+      double precision p(mxpart,4),cvec(3),cax(3),cl1(2),cl2(2),
      & ptZsafetycut_massless,ptZsafetycut_massive,ptZ,pttwo
       double precision phi,muk,rho,ssig,csig,theta,
      & p1true(4),p2true(4),p3true(4),p4true(4),p5true(4),p6true(4)
@@ -201,15 +201,19 @@ c --- Modified by Jeff
 c--- vector and axial couplings as an array for up/down quarks
       cvec(up)=half*(L(up)+R(up))
       cvec(dn)=half*(L(dn)+R(dn))
+      cvec(3)=half*(L(up)+R(up))
       cax(up)=half*(L(up)-R(up))
       cax(dn)=half*(L(dn)-R(dn))
+      cax(3)=half*(L(up)-R(up))
 
 c--- Optionally will add shifts to SM up and down type Zqq couplings
       if (AllowAnomalousZffCouplings .eq. 1) then 
         cvec(up)=half*(L(up)+R(up)) + (clanou+cranou)/2.
         cvec(dn)=half*(L(dn)+R(dn)) + (clanod+cranod)/2.
+        cvec(3)=half*(L(up)+R(up)) + (clanot+cranot)/2.
         cax(up)=half*(L(up)-R(up))  + (clanou-cranou)/2.
         cax(dn)=half*(L(dn)-R(dn))  + (clanod-cranod)/2.
+        cax(3)=half*(L(up)-R(up))  + (clanot-cranot)/2.
       endif
 
 c--- dress vector and axial amplitudes with appropriate couplings
@@ -250,8 +254,8 @@ c--- implementation of t-quark loop in terms of vector and axial couplings
       Amt_ax =2d0*(AmtLL(h1,h2,h34,h56)-AmtLR(h1,h2,h34,h56))
       Mloop_tquark(h1,h2,h34,h56)=im*(
      & Amt_vec*
-     & (Qu*q1+cvec(up)*cl1(h34)*prop34)*(Qu*q2+cvec(up)*cl2(h56)*prop56)
-     &+Amt_ax*(cax(up)*cl1(h34)*prop34)*(cax(up)*cl2(h56)*prop56))
+     & (Qu*q1+cvec(3)*cl1(h34)*prop34)*(Qu*q2+cvec(3)*cl2(h56)*prop56)
+     &+Amt_ax*(cax(3)*cl1(h34)*prop34)*(cax(3)*cl2(h56)*prop56))
       else
         Mloop_tquark(h1,h2,h34,h56)=czip
       endif


### PR DESCRIPTION
Fixes JHUGenLexicon by changing the MCFM at output to fit the multiplicative factor that JHUGen-MCFM uses

On the MELA side, additions to Ztt couplings were added to gluon-fusion background.